### PR TITLE
Expose transfer request event on clients

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Client/Controllers/Airship/Transfer.meta
+++ b/Assets/AirshipPackages/@Easy/Core/Client/Controllers/Airship/Transfer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cc1428ae146da4140b73a7c77c1b7e37
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AirshipPackages/@Easy/Core/Client/Controllers/Airship/Transfer/AirshipTransferController.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Client/Controllers/Airship/Transfer/AirshipTransferController.ts
@@ -1,0 +1,35 @@
+import { TransferControllerBridgeTopics } from "@Easy/Core/Client/ProtectedControllers/Transfer/TransferController";
+import { Platform } from "@Easy/Core/Shared/Airship";
+import { Controller } from "@Easy/Core/Shared/Flamework";
+import { Game } from "@Easy/Core/Shared/Game";
+import { Signal } from "@Easy/Core/Shared/Util/Signal";
+
+export interface AirshipTransferRequest {
+	gameId: string;
+	serverId: string;
+}
+
+/**
+ * Provides access to user information.
+ */
+@Controller({})
+export class AirshipTransferController {
+	/**
+	 * Fired when transfering between servers within your game. Does not fire when players exit your game.
+	 * If you need to perform actions on exit, use `Airship.Players.onPlayerDisconnected`.
+	 */
+	public readonly onTransferRequested: Signal<AirshipTransferRequest> =
+		new Signal<AirshipTransferRequest>().WithAllowYield(true);
+
+	constructor() {
+		if (!Game.IsClient()) return;
+
+		Platform.Client.Transfer = this;
+
+		contextbridge.callback(TransferControllerBridgeTopics.TransferRequested, (_, transfer) => {
+			this.onTransferRequested.Fire(transfer);
+		});
+	}
+
+	protected OnStart(): void {}
+}

--- a/Assets/AirshipPackages/@Easy/Core/Client/Controllers/Airship/Transfer/AirshipTransferController.ts.meta
+++ b/Assets/AirshipPackages/@Easy/Core/Client/Controllers/Airship/Transfer/AirshipTransferController.ts.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: bd658e431c88043a29db8693e1713d14
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: c4bd260abc8845c88b54ec021581f2a0, type: 3}

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Airship.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Airship.ts
@@ -2,6 +2,7 @@ import { AirshipMatchmakingController } from "../Client/Controllers/Airship/Matc
 import { AirshipPartyController } from "../Client/Controllers/Airship/Party/AirshipPartyController";
 import { AirshipPlatformInventoryController } from "../Client/Controllers/Airship/PlatformInventory/AirshipPlatformInventoryController";
 import { AirshipServerListController } from "../Client/Controllers/Airship/ServerList/AirshipServerListController";
+import { AirshipTransferController } from "../Client/Controllers/Airship/Transfer/AirshipTransferController";
 import { AirshipUserController } from "../Client/Controllers/Airship/User/AirshipUserController";
 import { AirshipCacheStoreService } from "../Server/Services/Airship/CacheStore/AirshipCacheStoreService";
 import { AirshipDataStoreService } from "../Server/Services/Airship/DataStore/AirshipDataStoreService";
@@ -138,6 +139,10 @@ export namespace Platform {
 		 * Provides information about the users matchmaking status.
 		 */
 		export let Matchmaking = undefined! as AirshipMatchmakingController;
+		/**
+		 * Provides information about server transfers.
+		 */
+		export let Transfer = undefined! as AirshipTransferController;
 	}
 }
 


### PR DESCRIPTION
This allows games to make custom transitions when transferring between servers in the same game.
- Games do not receive the event if the player is transferring out of the game
- Yielding is allowed for up to 10 seconds. (since this is intra-game transfers only, we could make this higher)

I also added a protected context event for transfers as well.