### PR TITLE
Smooth Camera Crouch Lerp

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Shared/Camera/DefaultCameraModes/FixedCameraMode.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Camera/DefaultCameraModes/FixedCameraMode.ts
@@ -174,16 +174,23 @@ export class FixedCameraMode extends CameraMode {
 		this.crouching = crouching;
 		this.crouchTweenBin.Clean();
 
+		const crouchTweenBaseSpeed = 0.16;
+		const percentStartCrouch = math.map(this.currentCrouchYOffset, 0, this.crouchYOffset, 0, 1);
+
 		if (crouching) {
+			const crouchTweenSpeed = crouchTweenBaseSpeed * (1 - percentStartCrouch);
 			this.crouchTweenBin.Add(
-				Tween.Number(TweenEasingFunction.Linear, 0.16, (val) => {
-					this.currentCrouchYOffset = val * this.crouchYOffset;
+				Tween.Number(TweenEasingFunction.Linear, crouchTweenSpeed, (val) => {
+					const mappedVal = math.map(val, 0, 1, percentStartCrouch, 1);
+					this.currentCrouchYOffset = mappedVal * this.crouchYOffset;
 				}),
 			);
 		} else {
+			const crouchTweenSpeed = crouchTweenBaseSpeed * percentStartCrouch;
 			this.crouchTweenBin.Add(
-				Tween.Number(TweenEasingFunction.Linear, 0.16, (val) => {
-					this.currentCrouchYOffset = (1 - val) * this.crouchYOffset;
+				Tween.Number(TweenEasingFunction.Linear, crouchTweenSpeed, (val) => {
+					const mappedVal = math.map(val, 0, 1, 1 - percentStartCrouch, 1);
+					this.currentCrouchYOffset = (1 - mappedVal) * this.crouchYOffset;
 				}),
 			);
 		}

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Camera/DefaultCameraModes/FixedCameraMode.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Camera/DefaultCameraModes/FixedCameraMode.ts
@@ -174,21 +174,22 @@ export class FixedCameraMode extends CameraMode {
 		this.crouching = crouching;
 		this.crouchTweenBin.Clean();
 
-		const crouchTweenBaseSpeed = 0.16;
+		const crouchTweenCrouchingBaseSpeed = 0.5;
+		const crouchTweenUncrouchingBaseSpeed = 0.5;
 		const percentStartCrouch = math.map(this.currentCrouchYOffset, 0, this.crouchYOffset, 0, 1);
 
 		if (crouching) {
-			const crouchTweenSpeed = crouchTweenBaseSpeed * (1 - percentStartCrouch);
+			const crouchTweenSpeed = crouchTweenCrouchingBaseSpeed * (1 - percentStartCrouch);
 			this.crouchTweenBin.Add(
-				Tween.Number(TweenEasingFunction.Linear, crouchTweenSpeed, (val) => {
+				Tween.Number(TweenEasingFunction.InOutQuad, crouchTweenSpeed, (val) => {
 					const mappedVal = math.map(val, 0, 1, percentStartCrouch, 1);
 					this.currentCrouchYOffset = mappedVal * this.crouchYOffset;
 				}),
 			);
 		} else {
-			const crouchTweenSpeed = crouchTweenBaseSpeed * percentStartCrouch;
+			const crouchTweenSpeed = crouchTweenUncrouchingBaseSpeed * percentStartCrouch;
 			this.crouchTweenBin.Add(
-				Tween.Number(TweenEasingFunction.Linear, crouchTweenSpeed, (val) => {
+				Tween.Number(TweenEasingFunction.InOutQuad, crouchTweenSpeed, (val) => {
 					const mappedVal = math.map(val, 0, 1, 1 - percentStartCrouch, 1);
 					this.currentCrouchYOffset = (1 - mappedVal) * this.crouchYOffset;
 				}),


### PR DESCRIPTION
### Description
The previous stuttery look was caused by the tween using the full crouch lerp even if we were only partially through the crouch to start with. I.e. if you were halfway down and decided to uncrouch, your camera would be instantly taken all the way to the bottom and then lerped to the top using the full amount of time.

The fix was to adjust the length of tween and map values based on our starting Y offset.


### Test Plan
I tested using a long tween time to visually see that the lerp started where we currently were (instead of at the full crouched and uncrouched Y offset). I also printed our current Y offset during the lerp and ensured there were no major jumps in numbers.

### Demo of Crouching with a long tween time (for better visualization)

https://github.com/user-attachments/assets/0da89509-53e2-49b1-91b0-fbca004eec56


### Demo with real timings


https://github.com/user-attachments/assets/24edd823-ec45-46aa-88de-76bace71048d



### Notes
You can still get the camera to jitter a bit due to how fast this lerp is. That's fairly unavoidable unless we implement a crouch cooldown. And in the future, we could consider adding that alongside teabag protection similar to what Counter Strike has
