### PR TITLE
Fix fly camera throwing exception when local character doesn't exist.

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Shared/Camera/AirshipCameraSingleton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Camera/AirshipCameraSingleton.ts
@@ -149,7 +149,10 @@ export class AirshipCameraSingleton {
 								this.SetFirstPerson(true);
 							}
 						});
-						flyingBin.Add(Dependency<LocalCharacterSingleton>().input!.AddDisabler());
+						const characterInput = Dependency<LocalCharacterSingleton>().GetCharacterInput();
+						if (characterInput) {
+							flyingBin.Add(characterInput.AddDisabler());
+						}
 						if (Airship.Inventory.localInventory) {
 							// TODO: luke add back disablers
 							// flyingBin.Add(Airship.Inventory.localInventory.AddControlsDisabler());


### PR DESCRIPTION
If you try to enter fly camera mode when the local character doesn't exist, an exception is thrown (`Dependency<LocalCharacterSingleton>().input` is `undefined`). This change allows fly cam to function properly whether or not the local character exists.