### PR TITLE
Adjust default camera offsets

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Shared/Character/CharacterConfigSetup.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Character/CharacterConfigSetup.ts
@@ -50,9 +50,9 @@ export default class CharacterConfigSetup extends AirshipBehaviour {
 
 	@Header("Character Camera Configuration")
 	@Header("Fixed Camera")
-	public fixedXOffset = 0.45;
+	public fixedXOffset = 0.75;
 	public fixedYOffset = 1.7;
-	public fixedZOffset = 3.5;
+	public fixedZOffset = 2.5;
 	public fixedMinRotX = 1;
 	public fixedMaxRotX = 179;
 	@Header("Orbit Camera")


### PR DESCRIPTION
This PR sets the camera offset to be the same as what felt best in BedWars. The old values put your character almost directly in front of your camera which felt weird to me (especially when I was making a shooter game)