### PR TITLE
Fix http errors thrown from UnityMakeRequest.

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Client/ProtectedControllers/Airship/User/UserController.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Client/ProtectedControllers/Airship/User/UserController.ts
@@ -5,7 +5,7 @@ import { Game } from "@Easy/Core/Shared/Game";
 import { Player } from "@Easy/Core/Shared/Player/Player";
 import { Protected } from "@Easy/Core/Shared/Protected";
 import { GameCoordinatorClient } from "@Easy/Core/Shared/TypePackages/game-coordinator-types";
-import { isUnityMakeRequestError, UnityMakeRequest } from "@Easy/Core/Shared/TypePackages/UnityMakeRequest";
+import { UnityMakeRequest, UnityMakeRequestError } from "@Easy/Core/Shared/TypePackages/UnityMakeRequest";
 import { AirshipUrl } from "@Easy/Core/Shared/Util/AirshipUrl";
 import { Signal } from "@Easy/Core/Shared/Util/Signal";
 import { AuthController } from "../../Auth/AuthController";
@@ -102,7 +102,7 @@ export class ProtectedUserController {
 			const result = await client.users.getByUid({ params: { uid: userId } });
 			return result.user;
 		} catch (err) {
-			if (isUnityMakeRequestError(err) && err.status === 404) {
+			if (UnityMakeRequestError.IsInstance(err) && err.status === 404) {
 				return undefined;
 			}
 			throw err;

--- a/Assets/AirshipPackages/@Easy/Core/Client/ProtectedControllers/Social/ChangeUsernameController.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Client/ProtectedControllers/Social/ChangeUsernameController.ts
@@ -13,7 +13,7 @@ import { OnFixedUpdate } from "@Easy/Core/Shared/Util/Timer";
 import { ProtectedUserController } from "../Airship/User/UserController";
 import { AuthController } from "../Auth/AuthController";
 import { GameCoordinatorClient } from "@Easy/Core/Shared/TypePackages/game-coordinator-types";
-import { isUnityMakeRequestError, UnityMakeRequest } from "@Easy/Core/Shared/TypePackages/UnityMakeRequest";
+import { UnityMakeRequest, UnityMakeRequestError } from "@Easy/Core/Shared/TypePackages/UnityMakeRequest";
 
 const client = new GameCoordinatorClient(UnityMakeRequest(AirshipUrl.GameCoordinator));
 
@@ -91,7 +91,7 @@ export class ChangeUsernameController {
 			this.submitButton.SetActive(false);
 			this.submitButtonDisabled.SetActive(true);
 		} catch (err) {
-			if (isUnityMakeRequestError(err) && err.status === 409) {
+			if (UnityMakeRequestError.IsInstance(err) && err.status === 409) {
 				this.SetResponseText("error", `The username "${text}" is taken.`);
 				return;
 			}
@@ -109,7 +109,7 @@ export class ChangeUsernameController {
 		this.submitButtonDisabled.SetActive(status !== "success");
 	}
 
-	protected OnStart(): void { }
+	protected OnStart(): void {}
 
 	private CheckUsername(): void {
 		let username = this.inputField.text;

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Search/SearchSingleton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Search/SearchSingleton.ts
@@ -84,7 +84,7 @@ export default class SearchSingleton {
 			});
 		} catch (err) {
 			if (UnityMakeRequestError.IsInstance(err)) {
-				const errorMessage = UnityMakeRequestError.DisplayText(err, "An unknown error occurred");
+				const errorMessage = UnityMakeRequestError.DisplayText(err) ?? "An unknown error occurred";
 				warn(`Failed to decode popular games: ${errorMessage}`);
 			}
 

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Search/SearchSingleton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Search/SearchSingleton.ts
@@ -3,7 +3,11 @@ import DateParser from "@Easy/Core/Shared/DateParser";
 import { Controller, Service } from "@Easy/Core/Shared/Flamework/flamework";
 import { Game } from "@Easy/Core/Shared/Game";
 import { ContentServiceClient, ContentServiceGames } from "@Easy/Core/Shared/TypePackages/content-service-types";
-import { isUnityMakeRequestError, UnityMakeRequest } from "@Easy/Core/Shared/TypePackages/UnityMakeRequest";
+import {
+	isUnityMakeRequestError,
+	UnityMakeRequest,
+	UnityMakeRequestError,
+} from "@Easy/Core/Shared/TypePackages/UnityMakeRequest";
 import { AirshipUrl } from "@Easy/Core/Shared/Util/AirshipUrl";
 import ObjectUtils from "@Easy/Core/Shared/Util/ObjectUtils";
 import { ProtectedUtil } from "@Easy/Core/Shared/Util/ProtectedUtil";
@@ -83,8 +87,9 @@ export default class SearchSingleton {
 				this.AddGames([...data.recentlyUpdated, ...data.popular]);
 			});
 		} catch (err) {
-			if (isUnityMakeRequestError(err)) {
-				warn("Failed to decode popular games: " + (err.responseMessage() ?? "An unknown error occurred"));
+			if (UnityMakeRequestError.IsInstance(err)) {
+				const errorMessage = UnityMakeRequestError.DisplayText(err, "An unknown error occurred");
+				warn(`Failed to decode popular games: ${errorMessage}`);
 			}
 
 			task.delay(1, () => {

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Search/SearchSingleton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Search/SearchSingleton.ts
@@ -3,11 +3,7 @@ import DateParser from "@Easy/Core/Shared/DateParser";
 import { Controller, Service } from "@Easy/Core/Shared/Flamework/flamework";
 import { Game } from "@Easy/Core/Shared/Game";
 import { ContentServiceClient, ContentServiceGames } from "@Easy/Core/Shared/TypePackages/content-service-types";
-import {
-	isUnityMakeRequestError,
-	UnityMakeRequest,
-	UnityMakeRequestError,
-} from "@Easy/Core/Shared/TypePackages/UnityMakeRequest";
+import { UnityMakeRequest, UnityMakeRequestError } from "@Easy/Core/Shared/TypePackages/UnityMakeRequest";
 import { AirshipUrl } from "@Easy/Core/Shared/Util/AirshipUrl";
 import ObjectUtils from "@Easy/Core/Shared/Util/ObjectUtils";
 import { ProtectedUtil } from "@Easy/Core/Shared/Util/ProtectedUtil";
@@ -64,7 +60,7 @@ export default class SearchSingleton {
 				this.myGamesIds.add(g.id);
 			}
 		} catch (err: unknown) {
-			if (isUnityMakeRequestError(err) && 400 <= err.status && err.status < 500) {
+			if (UnityMakeRequestError.IsInstance(err) && 400 <= err.status && err.status < 500) {
 				return;
 			}
 

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/SendFriendRequest/SendFriendRequestModal.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/SendFriendRequest/SendFriendRequestModal.ts
@@ -124,10 +124,8 @@ export default class SendFriendRequestModal extends AirshipBehaviour {
 			this.inputOutlineGO.SetActive(true);
 		} catch (err) {
 			if (UnityMakeRequestError.IsInstance(err)) {
-				this.responseText.text = UnityMakeRequestError.DisplayText(
-					err,
-					"Failed to send friend request. Please try again later.",
-				);
+				this.responseText.text =
+					UnityMakeRequestError.DisplayText(err) ?? "Failed to send friend request. Please try again later.";
 			} else {
 				this.responseText.text = "Failed to send friend request. Please try again later.";
 			}

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/SendFriendRequest/SendFriendRequestModal.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/SendFriendRequest/SendFriendRequestModal.ts
@@ -10,7 +10,11 @@ import { ColorUtil } from "@Easy/Core/Shared/Util/ColorUtil";
 import { Theme } from "@Easy/Core/Shared/Util/Theme";
 import AirshipButton from "../AirshipButton";
 import { GameCoordinatorClient } from "@Easy/Core/Shared/TypePackages/game-coordinator-types";
-import { isUnityMakeRequestError, UnityMakeRequest } from "@Easy/Core/Shared/TypePackages/UnityMakeRequest";
+import {
+	isUnityMakeRequestError,
+	UnityMakeRequest,
+	UnityMakeRequestError,
+} from "@Easy/Core/Shared/TypePackages/UnityMakeRequest";
 
 const client = new GameCoordinatorClient(UnityMakeRequest(AirshipUrl.GameCoordinator));
 
@@ -123,8 +127,11 @@ export default class SendFriendRequestModal extends AirshipBehaviour {
 			this.responseText.color = ColorUtil.HexToColor("#3BE267");
 			this.inputOutlineGO.SetActive(true);
 		} catch (err) {
-			if (isUnityMakeRequestError(err)) {
-				this.responseText.text = err.responseMessage() ?? "Failed to send friend request. Please try again later.";
+			if (UnityMakeRequestError.IsInstance(err)) {
+				this.responseText.text = UnityMakeRequestError.DisplayText(
+					err,
+					"Failed to send friend request. Please try again later.",
+				)!;
 			} else {
 				this.responseText.text = "Failed to send friend request. Please try again later.";
 			}

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/SendFriendRequest/SendFriendRequestModal.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/SendFriendRequest/SendFriendRequestModal.ts
@@ -10,11 +10,7 @@ import { ColorUtil } from "@Easy/Core/Shared/Util/ColorUtil";
 import { Theme } from "@Easy/Core/Shared/Util/Theme";
 import AirshipButton from "../AirshipButton";
 import { GameCoordinatorClient } from "@Easy/Core/Shared/TypePackages/game-coordinator-types";
-import {
-	isUnityMakeRequestError,
-	UnityMakeRequest,
-	UnityMakeRequestError,
-} from "@Easy/Core/Shared/TypePackages/UnityMakeRequest";
+import { UnityMakeRequest, UnityMakeRequestError } from "@Easy/Core/Shared/TypePackages/UnityMakeRequest";
 
 const client = new GameCoordinatorClient(UnityMakeRequest(AirshipUrl.GameCoordinator));
 
@@ -131,7 +127,7 @@ export default class SendFriendRequestModal extends AirshipBehaviour {
 				this.responseText.text = UnityMakeRequestError.DisplayText(
 					err,
 					"Failed to send friend request. Please try again later.",
-				)!;
+				);
 			} else {
 				this.responseText.text = "Failed to send friend request. Please try again later.";
 			}

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Settings/DeleteAccountButton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Settings/DeleteAccountButton.ts
@@ -21,15 +21,9 @@ export default class DeleteAccountButton extends AirshipBehaviour {
 						"Are you sure you want to delete your account? This cannot be undone.",
 					);
 					if (!confirmed) return;
-					try {
-						await client.users.deleteUser();
-						AuthManager.ClearSavedAccount();
-						Bridge.LoadScene("Login", true, LoadSceneMode.Single);
-					} catch (err) {
-						if (isUnityMakeRequestError(err)) {
-							error((err.responseMessage() ?? "An unknown error occurred"));
-						}
-					}
+					await client.users.deleteUser();
+					AuthManager.ClearSavedAccount();
+					Bridge.LoadScene("Login", true, LoadSceneMode.Single);
 				});
 			}),
 		);

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Settings/DeleteAccountButton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Settings/DeleteAccountButton.ts
@@ -3,8 +3,7 @@ import { AirshipUrl } from "@Easy/Core/Shared/Util/AirshipUrl";
 import { Bin } from "@Easy/Core/Shared/Util/Bin";
 import { CanvasAPI } from "@Easy/Core/Shared/Util/CanvasAPI";
 import { MainMenuSingleton } from "../../Singletons/MainMenuSingleton";
-import { HttpRetry } from "@Easy/Core/Shared/Http/HttpRetry";
-import { isUnityMakeRequestError, UnityMakeRequest } from "@Easy/Core/Shared/TypePackages/UnityMakeRequest";
+import { UnityMakeRequest } from "@Easy/Core/Shared/TypePackages/UnityMakeRequest";
 import { GameCoordinatorClient } from "@Easy/Core/Shared/TypePackages/game-coordinator-types";
 
 const client = new GameCoordinatorClient(UnityMakeRequest(AirshipUrl.GameCoordinator));

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Protected/Avatar/ProtectedAvatarSingleton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Protected/Avatar/ProtectedAvatarSingleton.ts
@@ -12,7 +12,7 @@ import { HttpRetryInstance } from "../../Http/HttpRetry";
 import { CoreLogger } from "../../Logger/CoreLogger";
 import { Protected } from "../../Protected";
 import { ContentServiceClient } from "../../TypePackages/content-service-types";
-import { isUnityMakeRequestError, UnityMakeRequest } from "../../TypePackages/UnityMakeRequest";
+import { isUnityMakeRequestError, UnityMakeRequest, UnityMakeRequestError } from "../../TypePackages/UnityMakeRequest";
 import { AirshipUrl } from "../../Util/AirshipUrl";
 import { ColorUtil } from "../../Util/ColorUtil";
 import { RandomUtil } from "../../Util/RandomUtil";
@@ -211,8 +211,9 @@ export class ProtectedAvatarSingleton {
 			const result = await contentServiceClient.outfits.getActiveOutfit();
 			return result.outfit;
 		} catch (err) {
-			if (isUnityMakeRequestError(err)) {
-				CoreLogger.Error("failed to load user equipped outfit: " + (err.responseMessage() ?? "Empty Data"));
+			if (UnityMakeRequestError.IsInstance(err)) {
+				const errorMessage = UnityMakeRequestError.DisplayText(err, "Empty Data");
+				CoreLogger.Error(`failed to load user equipped outfit: ${errorMessage}`);
 			}
 			throw err;
 		}
@@ -223,8 +224,9 @@ export class ProtectedAvatarSingleton {
 			const result = await contentServiceClient.outfits.getUserActiveOutfit({ uid: userId });
 			return result.outfit;
 		} catch (err) {
-			if (isUnityMakeRequestError(err)) {
-				CoreLogger.Error("failed to load users equipped outfit: " + (err.responseMessage() ?? "Empty Data"));
+			if (UnityMakeRequestError.IsInstance(err)) {
+				const errorMessage = UnityMakeRequestError.DisplayText(err, "Empty Data");
+				CoreLogger.Error(`failed to load users equipped outfit: ${errorMessage}`);
 			}
 			throw err;
 		}
@@ -235,8 +237,9 @@ export class ProtectedAvatarSingleton {
 			const result = await contentServiceClient.outfits.getOutfit({ outfitId });
 			return result.outfit;
 		} catch (err) {
-			if (isUnityMakeRequestError(err)) {
-				CoreLogger.Error("failed to load user outfit: " + (err.responseMessage() ?? "Empty Data"));
+			if (UnityMakeRequestError.IsInstance(err)) {
+				const errorMessage = UnityMakeRequestError.DisplayText(err, "Empty Data");
+				CoreLogger.Error(`failed to load user outfit: ${errorMessage}`);
 			}
 			throw err;
 		}
@@ -247,8 +250,9 @@ export class ProtectedAvatarSingleton {
 			const result = await contentServiceClient.outfits.createOutfit(outfit);
 			return result.outfit;
 		} catch (err) {
-			if (isUnityMakeRequestError(err)) {
-				CoreLogger.Error("Error creating outfit: " + (err.responseMessage() ?? "An unknown error occurred"));
+			if (UnityMakeRequestError.IsInstance(err)) {
+				const errorMessage = UnityMakeRequestError.DisplayText(err, "An unknown error occurred");
+				CoreLogger.Error(`Error creating outfit: ${errorMessage}`);
 			}
 			throw err;
 		}
@@ -258,8 +262,9 @@ export class ProtectedAvatarSingleton {
 		try {
 			await contentServiceClient.outfits.loadOutfit({ outfitId });
 		} catch (err) {
-			if (isUnityMakeRequestError(err)) {
-				CoreLogger.Error("Failed to equip outfit: " + (err.responseMessage() ?? "An unknown error occurred"));
+			if (UnityMakeRequestError.IsInstance(err)) {
+				const errorMessage = UnityMakeRequestError.DisplayText(err, "An unknown error occurred");
+				CoreLogger.Error(`Failed to equip outfit: ${errorMessage}`);
 			}
 			throw err;
 		}
@@ -313,8 +318,9 @@ export class ProtectedAvatarSingleton {
 		try {
 			return contentServiceClient.outfits.updateOutfit({ data: update, params: { outfitId } }).expect().outfit;
 		} catch (err) {
-			if (isUnityMakeRequestError(err)) {
-				CoreLogger.Error("Error Updating Outfit: " + (err.responseMessage() ?? "An unknown error occurred"));
+			if (UnityMakeRequestError.IsInstance(err)) {
+				const errorMessage = UnityMakeRequestError.DisplayText(err, "An unknown error occurred");
+				CoreLogger.Error(`Error Updating Outfit: ${errorMessage}`);
 			}
 			throw err;
 		}
@@ -371,10 +377,9 @@ export class ProtectedAvatarSingleton {
 
 			return imageId;
 		} catch (err) {
-			if (isUnityMakeRequestError(err)) {
-				CoreLogger.Error(
-					"Error getting item image resource: " + (err.responseMessage() ?? "An unknown error occurred"),
-				);
+			if (UnityMakeRequestError.IsInstance(err)) {
+				const errorMessage = UnityMakeRequestError.DisplayText(err, "An unknown error occurred");
+				CoreLogger.Error(`Error getting item image resource: ${errorMessage}`);
 			}
 			return "";
 		}

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Protected/Avatar/ProtectedAvatarSingleton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Protected/Avatar/ProtectedAvatarSingleton.ts
@@ -212,7 +212,7 @@ export class ProtectedAvatarSingleton {
 			return result.outfit;
 		} catch (err) {
 			if (UnityMakeRequestError.IsInstance(err)) {
-				const errorMessage = UnityMakeRequestError.DisplayText(err, "Empty Data");
+				const errorMessage = UnityMakeRequestError.DisplayText(err) ?? "Empty Data";
 				CoreLogger.Error(`failed to load user equipped outfit: ${errorMessage}`);
 			}
 			throw err;
@@ -225,7 +225,7 @@ export class ProtectedAvatarSingleton {
 			return result.outfit;
 		} catch (err) {
 			if (UnityMakeRequestError.IsInstance(err)) {
-				const errorMessage = UnityMakeRequestError.DisplayText(err, "Empty Data");
+				const errorMessage = UnityMakeRequestError.DisplayText(err) ?? "Empty Data";
 				CoreLogger.Error(`failed to load users equipped outfit: ${errorMessage}`);
 			}
 			throw err;
@@ -238,7 +238,7 @@ export class ProtectedAvatarSingleton {
 			return result.outfit;
 		} catch (err) {
 			if (UnityMakeRequestError.IsInstance(err)) {
-				const errorMessage = UnityMakeRequestError.DisplayText(err, "Empty Data");
+				const errorMessage = UnityMakeRequestError.DisplayText(err) ?? "Empty Data";
 				CoreLogger.Error(`failed to load user outfit: ${errorMessage}`);
 			}
 			throw err;
@@ -251,7 +251,7 @@ export class ProtectedAvatarSingleton {
 			return result.outfit;
 		} catch (err) {
 			if (UnityMakeRequestError.IsInstance(err)) {
-				const errorMessage = UnityMakeRequestError.DisplayText(err, "An unknown error occurred");
+				const errorMessage = UnityMakeRequestError.DisplayText(err) ?? "An unknown error occurred";
 				CoreLogger.Error(`Error creating outfit: ${errorMessage}`);
 			}
 			throw err;
@@ -263,7 +263,7 @@ export class ProtectedAvatarSingleton {
 			await contentServiceClient.outfits.loadOutfit({ outfitId });
 		} catch (err) {
 			if (UnityMakeRequestError.IsInstance(err)) {
-				const errorMessage = UnityMakeRequestError.DisplayText(err, "An unknown error occurred");
+				const errorMessage = UnityMakeRequestError.DisplayText(err) ?? "An unknown error occurred";
 				CoreLogger.Error(`Failed to equip outfit: ${errorMessage}`);
 			}
 			throw err;
@@ -319,7 +319,7 @@ export class ProtectedAvatarSingleton {
 			return contentServiceClient.outfits.updateOutfit({ data: update, params: { outfitId } }).expect().outfit;
 		} catch (err) {
 			if (UnityMakeRequestError.IsInstance(err)) {
-				const errorMessage = UnityMakeRequestError.DisplayText(err, "An unknown error occurred");
+				const errorMessage = UnityMakeRequestError.DisplayText(err) ?? "An unknown error occurred";
 				CoreLogger.Error(`Error Updating Outfit: ${errorMessage}`);
 			}
 			throw err;
@@ -378,7 +378,7 @@ export class ProtectedAvatarSingleton {
 			return imageId;
 		} catch (err) {
 			if (UnityMakeRequestError.IsInstance(err)) {
-				const errorMessage = UnityMakeRequestError.DisplayText(err, "An unknown error occurred");
+				const errorMessage = UnityMakeRequestError.DisplayText(err) ?? "An unknown error occurred";
 				CoreLogger.Error(`Error getting item image resource: ${errorMessage}`);
 			}
 			return "";

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Protected/Avatar/ProtectedAvatarSingleton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Protected/Avatar/ProtectedAvatarSingleton.ts
@@ -12,7 +12,7 @@ import { HttpRetryInstance } from "../../Http/HttpRetry";
 import { CoreLogger } from "../../Logger/CoreLogger";
 import { Protected } from "../../Protected";
 import { ContentServiceClient } from "../../TypePackages/content-service-types";
-import { isUnityMakeRequestError, UnityMakeRequest, UnityMakeRequestError } from "../../TypePackages/UnityMakeRequest";
+import { UnityMakeRequest, UnityMakeRequestError } from "../../TypePackages/UnityMakeRequest";
 import { AirshipUrl } from "../../Util/AirshipUrl";
 import { ColorUtil } from "../../Util/ColorUtil";
 import { RandomUtil } from "../../Util/RandomUtil";

--- a/Assets/AirshipPackages/@Easy/Core/Shared/TypePackages/UnityMakeRequest.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/TypePackages/UnityMakeRequest.ts
@@ -59,7 +59,10 @@ export type UnityMakeRequestError = {
 	status: number;
 };
 
-export const UnityMakeRequestError = {
+/**
+ * Static helper functions which can be applied for a UnityMakeRequestError type.
+ */
+interface UnityMakeRequestErrorStaticFunctions {
 	/**
 	 * Checks if a thrown error fits the object shape of a known error.
 	 *
@@ -68,26 +71,43 @@ export const UnityMakeRequestError = {
 	 * @param err The thrown object to check.
 	 * @returns True if the thrown object follows the shape of the UnityMakeRequestError type, false otherwise.
 	 */
-	IsInstance: (err: unknown) => {
-		return isUnityMakeRequestError(err);
-	},
+	IsInstance(error: unknown): error is UnityMakeRequestError;
 	/**
 	 * Creates a friendly display text from the provided error based on conventional api responses.
 	 *
-	 * @param err The error to create the display text from.
+	 * @param error The error to create the display text from.
 	 * @param defaultValue A value which can be provided to guarantee a value is returned.
-	 * @returns The decoded error message or first validation error message if the error matches
-	 * 	a normal validation error, otherwise it will return the defaultValue.
+	 * @returns The decoded error message or first validation error, otherwise it will return the defaultValue.
 	 */
-	DisplayText: (err: UnityMakeRequestError, defaultValue?: string | undefined) => {
-		return UnityMakeRequestErrorDisplayText(err, defaultValue);
-	},
+	DisplayText(error: UnityMakeRequestError, defaultValue: string): string;
+	// DisplayText(error: UnityMakeRequestError) needs separate docs since it has no defaultValue defined.
+	/**
+	 * Creates a friendly display text from the provided error based on conventional api responses.
+	 *
+	 * @param error The error to create the display text from.
+	 * @returns The decoded error message or first validation error, otherwise it will return undefined.
+	 */
+	DisplayText(error: UnityMakeRequestError): string | undefined;
+	DisplayText(error: UnityMakeRequestError, defaultValue: string | undefined): string | undefined;
+}
+
+/**
+ * A helper object to operate on UnityMakeRequest errors.
+ */
+export const UnityMakeRequestError: UnityMakeRequestErrorStaticFunctions = {
+	IsInstance: IsUnityMakeRequestError,
+	DisplayText: UnityMakeRequestErrorDisplayText,
 };
 
-function UnityMakeRequestErrorDisplayText(
-	error: UnityMakeRequestError,
-	defaultValue?: string | undefined,
-): string | undefined {
+function IsUnityMakeRequestError(err: unknown): err is UnityMakeRequestError {
+	if (!err) return false;
+	const typedErr = err as Partial<UnityMakeRequestError>;
+	return typedErr.message !== undefined && typedErr.status !== undefined;
+}
+
+function UnityMakeRequestErrorDisplayText(error: UnityMakeRequestError): string | undefined;
+function UnityMakeRequestErrorDisplayText(error: UnityMakeRequestError, defaultValue: string): string;
+function UnityMakeRequestErrorDisplayText(error: UnityMakeRequestError, defaultValue?: string): string | undefined {
 	let responseMessage: string | undefined;
 	try {
 		// Attempt to extract the message property from the response object.
@@ -110,20 +130,6 @@ function UnityMakeRequestErrorDisplayText(
 		responseMessage = defaultValue;
 	}
 	return responseMessage;
-}
-
-/**
- * Checks if a thrown error fits the object shape of a known error.
- *
- * This provides type narrowing for the UnityMakeRequestError type.
- *
- * @param err The thrown object to check.
- * @returns True if the thrown object follows the shape of the UnityMakeRequestError type, false otherwise.
- */
-export function isUnityMakeRequestError(err: unknown): err is UnityMakeRequestError {
-	if (!err) return false;
-	const typedErr = err as Partial<UnityMakeRequestError>;
-	return typedErr.message !== undefined && typedErr.status !== undefined;
 }
 
 export function UnityMakeRequest(baseUrl: string): MakeRequest {

--- a/Assets/AirshipPackages/@Easy/Core/Shared/TypePackages/UnityMakeRequest.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/TypePackages/UnityMakeRequest.ts
@@ -76,19 +76,9 @@ interface UnityMakeRequestErrorStaticFunctions {
 	 * Creates a friendly display text from the provided error based on conventional api responses.
 	 *
 	 * @param error The error to create the display text from.
-	 * @param defaultValue A value which can be provided to guarantee a value is returned.
-	 * @returns The decoded error message or first validation error, otherwise it will return the defaultValue.
-	 */
-	DisplayText(error: UnityMakeRequestError, defaultValue: string): string;
-	// DisplayText(error: UnityMakeRequestError) needs separate docs since it has no defaultValue defined.
-	/**
-	 * Creates a friendly display text from the provided error based on conventional api responses.
-	 *
-	 * @param error The error to create the display text from.
 	 * @returns The decoded error message or first validation error, otherwise it will return undefined.
 	 */
 	DisplayText(error: UnityMakeRequestError): string | undefined;
-	DisplayText(error: UnityMakeRequestError, defaultValue: string | undefined): string | undefined;
 }
 
 /**
@@ -105,9 +95,7 @@ function IsUnityMakeRequestError(err: unknown): err is UnityMakeRequestError {
 	return typedErr.message !== undefined && typedErr.status !== undefined;
 }
 
-function UnityMakeRequestErrorDisplayText(error: UnityMakeRequestError): string | undefined;
-function UnityMakeRequestErrorDisplayText(error: UnityMakeRequestError, defaultValue: string): string;
-function UnityMakeRequestErrorDisplayText(error: UnityMakeRequestError, defaultValue?: string): string | undefined {
+function UnityMakeRequestErrorDisplayText(error: UnityMakeRequestError): string | undefined {
 	let responseMessage: string | undefined;
 	try {
 		// Attempt to extract the message property from the response object.
@@ -124,10 +112,10 @@ function UnityMakeRequestErrorDisplayText(error: UnityMakeRequestError, defaultV
 				responseMessage = tostring(errObj.message);
 			}
 		} else {
-			responseMessage = defaultValue;
+			return;
 		}
 	} catch {
-		responseMessage = defaultValue;
+		return;
 	}
 	return responseMessage;
 }


### PR DESCRIPTION
- Don't double print error.
- Don't pass responseMessage function through bridge.