### PR TITLE
Fix/mobile in game UI

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Client/ProtectedControllers/MainMenuController.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Client/ProtectedControllers/MainMenuController.ts
@@ -47,6 +47,9 @@ export class MainMenuController {
 
 	private gameCursorLocked = false;
 
+	/** Works from protected context. */
+	public onToggled = new Signal<[opened: boolean]>();
+
 	public activeTransferToast: TransferToast | undefined;
 	private mainMenu: MainMenuComponent;
 
@@ -174,6 +177,8 @@ export class MainMenuController {
 		// }
 		this.RouteToPage(MainMenuPageType.Game, true, true);
 
+		this.onToggled.Fire(true);
+
 		//CloudImage.PrintCache();
 	}
 
@@ -195,6 +200,7 @@ export class MainMenuController {
 				this.mainContentCanvas.enabled = false;
 			}
 		});
+		this.onToggled.Fire(false);
 	}
 
 	public IsOpen(): boolean {

--- a/Assets/AirshipPackages/@Easy/Core/Prefabs/Images/CoreIcons/bars-solid-full.png
+++ b/Assets/AirshipPackages/@Easy/Core/Prefabs/Images/CoreIcons/bars-solid-full.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd50f3d5b55b0f950939894b4f067615933f30d9b93256294d277d68e11626ec
+size 1903

--- a/Assets/AirshipPackages/@Easy/Core/Prefabs/Images/CoreIcons/bars-solid-full.png.meta
+++ b/Assets/AirshipPackages/@Easy/Core/Prefabs/Images/CoreIcons/bars-solid-full.png.meta
@@ -1,0 +1,156 @@
+fileFormatVersion: 2
+guid: 949b7916975d34d869c673370d212270
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 1
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: iOS
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    customData: 
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AirshipPackages/@Easy/Core/Prefabs/UI/MobileControls/AirshipOverlayCanvas.prefab
+++ b/Assets/AirshipPackages/@Easy/Core/Prefabs/UI/MobileControls/AirshipOverlayCanvas.prefab
@@ -50,7 +50,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   guid: edd104cb-b700-47e8-83c9-024e8eb5604f
-  hash: 2d2c40f1ea295469e9af386971e1b808
   script: {fileID: -5374682861176321385, guid: d47d161ec37da694184ffeb6dd7bbea3, type: 3}
   scriptPath: Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Overlay/MicIndicator.lua
   forceContext: 0
@@ -182,7 +181,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.25485048, g: 0.40121812, b: 0.6509434, a: 0.7529412}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.9019608}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 0
@@ -226,7 +225,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   guid: 4e01b257-6da1-4adf-be6a-605587792389
-  hash: 6c7ccb9d04568b1f4fcaba2db33a3365
   script: {fileID: 247699700030261788, guid: 6155702a7b8e9f445b9ce853cd33d000, type: 3}
   scriptPath: Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/AirshipButton.lua
   forceContext: 0
@@ -396,7 +394,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   guid: c2099bf4-859c-4ae8-a73f-17af2d5d856b
-  hash: ce718305014ba0af193569aa91c211a0
   script: {fileID: 1680349167810770225, guid: 7cf094551c5c8384d98ad7d110e87bc0, type: 3}
   scriptPath: Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/MobileChatToggleButton.lua
   forceContext: 0
@@ -424,7 +421,7 @@ MonoBehaviour:
         - type: string
           serializedValue: '"Variables"'
       nullable: 0
-      serializedValue: '{"r":0.2549019753932953,"g":0.4000000059604645,"b":0.6509804129600525,"a":0.7529411911964417}'
+      serializedValue: '{"r":0.3366411328315735,"g":0.5070777535438538,"b":0.801886796951294,"a":0.9019607901573181}'
       serializedObject: {fileID: 0}
       modified: 1
     - name: disabledColor
@@ -442,7 +439,7 @@ MonoBehaviour:
         tags: []
       decorators: []
       nullable: 0
-      serializedValue: '{"r":0.0,"g":0.0,"b":0.0,"a":0.7529411911964417}'
+      serializedValue: '{"r":0.0,"g":0.0,"b":0.0,"a":0.9019607901573181}'
       serializedObject: {fileID: 0}
       modified: 1
     - name: bgImage
@@ -1065,7 +1062,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   guid: df3aacb3-2463-4855-b3d5-481f7aeec983
-  hash: 3784e31054a0d889cfc67be3a5cc0f53
   script: {fileID: 3015346204361807020, guid: 373b9afc2f33f584ca3e01c1ab016214, type: 3}
   scriptPath: Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Overlay/AirshipOverlayManager.lua
   forceContext: 0
@@ -1234,7 +1230,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.7529412}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.9019608}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 0
@@ -1278,7 +1274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   guid: c4428657-3b75-4415-926c-956bacf1bb14
-  hash: 6c7ccb9d04568b1f4fcaba2db33a3365
   script: {fileID: 247699700030261788, guid: 6155702a7b8e9f445b9ce853cd33d000, type: 3}
   scriptPath: Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/AirshipButton.lua
   forceContext: 0
@@ -1448,7 +1443,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   guid: f184bb1a-6904-425d-bd37-463ecf12e1d0
-  hash: 1688bd52be391997fdfaa05d77bfc853
   script: {fileID: -2757413630953409776, guid: 61c16a076aafe98478bf9973d2c092c0, type: 3}
   scriptPath: Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/MobileEscapeButton.lua
   forceContext: 0
@@ -1542,7 +1536,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 96348075dd60c45fca1607b877f6f95b, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 949b7916975d34d869c673370d212270, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/AirshipPackages/@Easy/Core/Prefabs/UI/MobileControls/AirshipOverlayCanvas.prefab
+++ b/Assets/AirshipPackages/@Easy/Core/Prefabs/UI/MobileControls/AirshipOverlayCanvas.prefab
@@ -210,7 +210,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ec18a89aa0caf4669ae44f413c827581, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  radius: 10
+  radius: 5
   image: {fileID: 7364803093370303956}
 --- !u!114 &3148614413205817047
 MonoBehaviour:
@@ -1259,7 +1259,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ec18a89aa0caf4669ae44f413c827581, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  radius: 10
+  radius: 5
   image: {fileID: 2334693357248109831}
 --- !u!114 &5357714595913634351
 MonoBehaviour:

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Game.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Game.ts
@@ -180,20 +180,26 @@ export class Game {
 	 */
 	public static GetScaleFactor(): number {
 		let dpi = Screen.dpi;
+		let width = Screen.width;
 
 		if (Game.IsMobile()) {
 			if (Game.deviceType === AirshipDeviceType.Tablet) {
 				return dpi / 180;
 			}
-			print("dpi: " + dpi);
 
-			// iPhone 7 scaling
-			// if (Game.platform === AirshipPlatform.iOS && dpi < 326) {
-			// 	return dpi / 180;
-			// }
+			// Screen width, height:
+			// iPhone 12: 1170, 2532
+			// iPhone 7: 750, 1334
+
+			// print("screen size: " + Screen.width + ", " + Screen.height);
+
+			// Special handling for newer iphones.
+			// This feels very very bad. We should get rid of this.
+			if (Game.IsPortrait() && Game.platform === AirshipPlatform.iOS && width > 750) {
+				return math.max(2.5555, dpi / 180);
+			}
 
 			return dpi / 180;
-			// return math.max(2.5555, dpi / 180);
 		} else if (dpi >= 255) {
 			return 1.75;
 		} else {

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Game.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Game.ts
@@ -1,3 +1,4 @@
+import { Airship } from "./Airship";
 import type { AirshipGameWithOrg } from "./Airship/Types/AirshipGame";
 import { CoreContext } from "./CoreClientContext";
 import { CoreNetwork } from "./CoreNetwork";
@@ -29,6 +30,8 @@ export class Game {
 	 * Fired when the local player opens the Main Menu (escape key).
 	 *
 	 * You can also use {@link IsMenuOpen()} to check if opened.
+	 *
+	 * @deprecated use `Airship.Menu.onMenuOpened` instead
 	 */
 	public static readonly onMenuOpened = new Signal<[opened: boolean]>();
 
@@ -85,6 +88,8 @@ export class Game {
 	 * Used to check if the Airship Escape Menu is opened.
 	 *
 	 * @returns True if the Airship Escape Menu is open.
+	 *
+	 * @deprecated Use `Airship.Menu.IsMenuOpen()` instead.
 	 */
 	public static IsMenuOpen(): boolean {
 		if (Game.IsGameLuauContext()) {
@@ -180,7 +185,15 @@ export class Game {
 			if (Game.deviceType === AirshipDeviceType.Tablet) {
 				return dpi / 180;
 			}
-			return math.max(2.5555, dpi / 180);
+			print("dpi: " + dpi);
+
+			// iPhone 7 scaling
+			// if (Game.platform === AirshipPlatform.iOS && dpi < 326) {
+			// 	return dpi / 180;
+			// }
+
+			return dpi / 180;
+			// return math.max(2.5555, dpi / 180);
 		} else if (dpi >= 255) {
 			return 1.75;
 		} else {
@@ -215,6 +228,7 @@ export class Game {
 
 if (Game.IsGameLuauContext()) {
 	contextbridge.subscribe("Game:MenuToggled", (from, opened: boolean) => {
+		Airship.Menu.onMenuToggled.Fire(opened);
 		Game.onMenuOpened.Fire(opened);
 	});
 }

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/MobileEscapeButton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/MobileEscapeButton.ts
@@ -14,10 +14,8 @@ export default class MobileEscapeButton extends AirshipBehaviour {
 				const mainMenuController = Dependency<MainMenuController>();
 				if (mainMenuController.IsOpen()) {
 					mainMenuController.CloseFromGame();
-					this.chatButton.SetActive(true);
 				} else {
 					mainMenuController.OpenFromGameInProtectedContext();
-					this.chatButton.SetActive(false);
 				}
 			}),
 		);

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Overlay/AirshipOverlayManager.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Overlay/AirshipOverlayManager.ts
@@ -1,3 +1,4 @@
+import { MainMenuController } from "@Easy/Core/Client/ProtectedControllers/MainMenuController";
 import { Dependency } from "@Easy/Core/Shared/Flamework";
 import { Game } from "@Easy/Core/Shared/Game";
 import { ControlScheme, Preferred } from "@Easy/Core/Shared/UserInput";
@@ -38,6 +39,11 @@ export default class AirshipOverlayManager extends AirshipBehaviour {
 		mainMenu.onHideMobileEscapeButtonChanged.Connect((hide) => {
 			if (!Game.IsMobile()) return;
 			this.escapeButton.gameObject.SetActive(!hide);
+		});
+
+		Dependency<MainMenuController>().onToggled.Connect((opened) => {
+			if (!Game.IsMobile()) return;
+			this.chatButton.gameObject.SetActive(!opened);
 		});
 	}
 

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Menu/AirshipMenuSingleton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Menu/AirshipMenuSingleton.ts
@@ -1,13 +1,17 @@
 import { TabListController } from "@Easy/Core/Client/Controllers/TabList/TabListController";
 import { Airship } from "@Easy/Core/Shared/Airship";
 import { Dependency, OnStart, Singleton } from "@Easy/Core/Shared/Flamework";
-import { Signal } from "@Easy/Core/Shared/Util/Signal";
-import { AirshipMatchmakingGroup } from "../Airship/Types/Matchmaking";
 import { Game } from "../Game";
+import { Signal } from "../Util/Signal";
 
 @Singleton({})
 export class AirshipMenuSingleton implements OnStart {
-	public readonly onGroupChange: Signal<AirshipMatchmakingGroup> = new Signal();
+	/**
+	 * Fired when the local player opens and closes the Main Menu (escape key).
+	 *
+	 * You can also use {@link IsMenuOpen()} to check if opened.
+	 */
+	public readonly onMenuToggled = new Signal<[opened: boolean]>();
 
 	private leaveMatchBtnCallback: (() => void) | undefined;
 
@@ -22,6 +26,18 @@ export class AirshipMenuSingleton implements OnStart {
 	}
 
 	public OnStart(): void {}
+
+	/**
+	 * Used to check if the Airship Escape Menu is opened.
+	 *
+	 * @returns True if the Airship Escape Menu is open.
+	 */
+	public static IsMenuOpen(): boolean {
+		if (Game.IsGameLuauContext()) {
+			return contextbridge.invoke("Game:IsMenuOpen", LuauContext.Protected);
+		}
+		return false;
+	}
 
 	/**
 	 * Adds a special "Leave Match" button.


### PR DESCRIPTION
- Improved in-game and main menu scaling on smaller phone screens
- New menu mobile in-game button (used to be a leaf, now it's a proper menu icon). Also made colors darker and adjusted border.
- Added `Airship.Menu.onMenuToggled` signal and `Airship.Menu.IsMenuOpen()`. Deprecated similar methods in `Game.ts`

iPhone 7:
<img width="857" height="457" alt="Screenshot 2025-08-12 at 3 01 12 PM" src="https://github.com/user-attachments/assets/ad9f1e67-dbb8-41c5-b3cc-b313f7c011b9" />

<img width="513" height="880" alt="Screenshot 2025-08-13 at 8 48 35 AM" src="https://github.com/user-attachments/assets/8985ebc2-e7ac-4d33-9a41-844a83b251fa" />

