### PR TITLE
Emote ratelimit to prevent malicious actors

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Shared/Emote/InternalEmoteDef.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Emote/InternalEmoteDef.ts
@@ -68,6 +68,7 @@ for (let id of ObjectUtils.keys(defs)) {
 	(defs[id] as any).id = id;
 }
 
+export const EmoteCooldown = 0.1;
 export const InternalEmoteDefinitions: {
 	[key in EmoteId]: EmoteDefinition;
 } = defs as {


### PR DESCRIPTION
Mitigating a simple ClientCrasher method through client object spam.
<img width="655" height="289" alt="Code_JEbP3V8Kql" src="https://github.com/user-attachments/assets/f9d2c295-3c07-44eb-9000-87f7651be82c" />
