### PR TITLE
enabled GPU instancing on our core material library

### DIFF
--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Clay.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Clay.mat
@@ -28,7 +28,7 @@ Material:
   - _ENVIRONMENTREFLECTIONS_OFF
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: 2050
   stringTagMap:

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Concrete.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Concrete.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/HumanMaterials/FlatHair.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/HumanMaterials/FlatHair.mat
@@ -14,7 +14,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap:

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/HumanMaterials/Skin.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/HumanMaterials/Skin.mat
@@ -1,5 +1,18 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-6445319153931784583
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 9
 --- !u!21 &2100000
 Material:
   serializedVersion: 8
@@ -8,38 +21,28 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Skin
-  m_Shader: {fileID: 4800000, guid: b8fcfddb128a0284e9f5e927061e61d1, type: 3}
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords:
-  - EXPLICIT_MAPS_ON
-  - SHADOWS_ON
-  - TRIPLANAR_STYLE_OFF
-  m_InvalidKeywords:
-  - EXPLICIT_MAPS
-  - METAL_ON_ON
-  - NUM_LIGHTS_LIGHTS2
-  - SLIDER_OVERRIDE
-  - SLIDER_OVERRIDE_ON
-  - _DSTBLEND_ZERO
-  - _LIGHTS_LIGHTS0
-  - _SRCBLEND_ONE
-  - _SURFACETYPE_OPAQUE
-  - _TRIPLANAR_LOCAL
-  - _TRIPLANAR_TRIPLANAR_LOCAL
-  - _ZWRITE_ON
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2000
+  m_CustomRenderQueue: -1
   stringTagMap:
     RenderType: Opaque
-  disabledShaderPasses: []
+  disabledShaderPasses:
+  - MOTIONVECTORS
   m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
     - _AOTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BaseMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -76,8 +79,8 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 631016985ed5ef34b8681ff253d3709f, type: 3}
-        m_Scale: {x: 10, y: 10}
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetalTex:
         m_Texture: {fileID: 2800000, guid: c68c0c05d862ba24c874a924c7bb4a33, type: 3}
@@ -107,11 +110,19 @@ Material:
         m_Texture: {fileID: 2800000, guid: 781266cb27b0c364b8e44e55f768a517, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - unity_Lightmaps:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -135,15 +146,26 @@ Material:
     - USE_COLOR_MASK_ON: 0
     - USE_SHADOW_COLOR: 0
     - VERTEX_LIGHT: 0
+    - _AddPrecomputedVelocity: 0
     - _Alpha: 1
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
     - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
     - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
+    - _DstBlendAlpha: 0
     - _EXPLICIT_MAPS: 1
     - _Emissive: 0
     - _EmissiveLevel: 0
     - _EmissiveMix: 0
+    - _EnvironmentReflections: 1
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
@@ -151,30 +173,37 @@ Material:
     - _Lights: 0
     - _MRSliderOverrideMix: 0.5
     - _MetalOverride: 0
-    - _Metallic: 0
+    - _Metallic: 0.11
     - _Mode: 0
     - _OcclusionStrength: 1
     - _OverrideStrength: 0
     - _POINT_FILTER: 1
     - _Parallax: 0.02
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
     - _RimIntensity: 0.47
     - _RimPower: 4.46
     - _RoughOverride: 0.65
     - _SLIDER_OVERRIDE: 1
     - _SkyShineStrength: 0
     - _SliderOverrideMix: 0
+    - _Smoothness: 0.22
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
     - _SunScale: 1
+    - _Surface: 0
     - _SurfaceType: 0
     - _Triplanar: 1
     - _TriplanarScale: 8.8
     - _UVSec: 0
     - _VERTEX_LIGHT: 0
+    - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 0.7264151, g: 0.45594165, b: 0.3529281, a: 1}
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _EmissiveColor: {r: 0, g: 0.15327406, b: 1, a: 1}
     - _IncidentColor: {r: 0.4, g: 0.75, b: 1, a: 1}
@@ -183,6 +212,7 @@ Material:
     - _ShadowColor: {r: 1, g: 1, b: 1, a: 1}
     - _ShadowTint: {r: 1, g: 1, b: 1, a: 1}
     - _SkyShine: {r: 0.4, g: 0.75, b: 1, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
     - _SpecularColor: {r: 1, g: 0.6839622, b: 0.6839622, a: 1}
   m_BuildTextureStacks: []
   m_AllowLocking: 1

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Metal.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Metal.mat
@@ -14,7 +14,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Black_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Black_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Blue_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Blue_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Blue_Sapphire_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Blue_Sapphire_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Dark_Blue_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Dark_Blue_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Dark_Gray_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Dark_Gray_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Gray_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Gray_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Green_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Green_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Ground/Blue_Ground_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Ground/Blue_Ground_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Ground/Dark_Ground_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Ground/Dark_Ground_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Ground/Gray_Ground_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Ground/Gray_Ground_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Light_Gray_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Light_Gray_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Light_Sea_Green_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Light_Sea_Green_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Mantis_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Mantis_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Orange_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Orange_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Red_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Red_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Violet_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Violet_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/White_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/White_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Yellow_Prototype.mat
+++ b/Assets/AirshipPackages/@Easy/CoreMaterials/MaterialLibrary/Prototype/Yellow_Prototype.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}


### PR DESCRIPTION
 I noticed our core materials didn't have GPU instancing checked. Seems like we should have them checked for an easy performance boost on peoples prototypes.