### PR TITLE
Make sure connections are cleaned up if character is disabled

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Shared/Character/Character.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Character/Character.ts
@@ -243,8 +243,8 @@ export default class Character extends AirshipBehaviour {
 			bin.Clean();
 		}
 		this.observeHeldSlotBins.clear();
+		this.bin.Clean();
 		if (Game.IsClient() && !this.despawned) {
-			this.bin.Clean();
 			this.despawned = true;
 			this.onDespawn.Fire();
 			Airship.Characters.onCharacterDespawned.Fire(this);


### PR DESCRIPTION
If a character is disabled on the server (for whatever reason) and re-enabled, it will create the connections again without cleaning them up - leading to listeners being called multiple times. With Mirror, this can happen with network-based objects.

```ts
	public OnEnable(): void {
        // ...
		this.bin.Add(...); // repeat this a few times
	}

	public OnDisable(): void {
        // ...
		if (Game.IsClient() && !this.despawned) {
			this.bin.Clean(); // <-- only cleaning up here
			this.despawned = true;
			this.onDespawn.Fire();
			Airship.Characters.onCharacterDespawned.Fire(this);
			if (this.player?.character === this) {
				this.player?.SetCharacter(undefined);
			}
		}
	}
```

This was obvious when my NPCs were taking twice the damage on the server compared to the client through `onDamage` using `SetHealth`.


```ts
		this.bin.Add(
			Airship.Damage.onDamage.ConnectWithPriority(SignalPriority.MONITOR, (damageInfo) => {
				if (damageInfo.gameObject.GetInstanceID() === this.gameObject.GetInstanceID()) {
					if (this.IsDead()) return;
					let newHealth = math.max(0, this.health - damageInfo.damage);

					this.SetHealth(newHealth, true, true); // <-- this invokes twice on server if the character was disabled and re-enabled, doesn't replicate to the client
				}
			}),
		);1
```