### PR TITLE
Added a visibility toggle for mobile inputs

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Shared/Input/AirshipInputSingleton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Input/AirshipInputSingleton.ts
@@ -103,6 +103,11 @@ export class AirshipInputSingleton {
 	 */
 	private gameSensitivityMultiplier = 1;
 
+	/*
+	 * Core mobile inputs
+	 */
+	private mobileControlCanvas: MobileControlsCanvas;
+
 	public preferredControls = new PreferredControls();
 
 	public isSprintToggleSprinting = false;
@@ -448,7 +453,7 @@ export class AirshipInputSingleton {
 		this.mobileControlsContainer = mobileControlsCanvas;
 		this.mobileCameraControlContainer = mobileCameraControlCanvas;
 
-		const controls = this.mobileControlsContainer.GetAirshipComponent<MobileControlsCanvas>()!;
+		this.mobileControlCanvas = this.mobileControlsContainer.GetAirshipComponent<MobileControlsCanvas>()!;
 
 		this.controlManager.ObserveControlScheme((controlScheme) => {
 			if (controlScheme === ControlScheme.Touch) {
@@ -465,7 +470,7 @@ export class AirshipInputSingleton {
 			}
 		});
 
-		controls.Init();
+		this.mobileControlCanvas.Init();
 	}
 
 	/**
@@ -654,6 +659,30 @@ export class AirshipInputSingleton {
 		const mobileButtonsForAction = this.actionToMobileButtonTable.get(name.lower()) ?? [];
 		for (const mobileButton of mobileButtonsForAction) {
 			mobileButton.SetActive(true);
+		}
+	}
+
+	public SetMobileButtonsVisibility(visible: boolean) {
+		//Toggle core mobile inputs
+		this.mobileControlCanvas.enabled = visible;
+
+		//Toggle all mobile buttons
+		for (const [key, objects] of this.actionToMobileButtonTable) {
+			if (visible) {
+				this.ShowMobileButtons(key);
+			} else {
+				this.HideMobileButtons(key);
+			}
+		}
+
+		//Disable Joysticks
+		const moveJoy = this.GetMobileTouchJoystick();
+		if (moveJoy) {
+			moveJoy.SetActive(visible);
+		}
+		const camJoy = this.GetMobileCameraMovement();
+		if (camJoy) {
+			camJoy.SetActive(visible);
 		}
 	}
 

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/DynamicJoystick.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/DynamicJoystick.ts
@@ -62,20 +62,31 @@ export default class DynamicJoystick extends AirshipBehaviour {
 
 		this.bin.AddEngineEventConnection(
 			CanvasAPI.OnEndDragEvent(this.dragTarget.gameObject, (data) => {
-				this.mobileCameraMovement?.EndDragEvent(data);
+				this.mobileCameraMovement?.EndDragEvent(data.pointerId);
 
 				// Only end joystick if this was the joystick touch
 				if (this.joystickTouchId === data.pointerId) {
-					NativeTween.AnchoredPosition(this.handleInner, Vector2.zero, 0.1).SetUseUnscaledTime(true);
-					NativeTween.GraphicAlpha(this.handleOuterImage, 0, 0.2).SetUseUnscaledTime(true);
-					NativeTween.GraphicAlpha(this.handleInnerImage, 0, 0.2).SetUseUnscaledTime(true);
-					NativeTween.GraphicAlpha(this.handleOuterOutline, 0, 0.2).SetUseUnscaledTime(true);
-					this.input = Vector2.zero;
-					this.dragging = false;
-					this.joystickTouchId = -1;
+					this.StopDrag(false);
 				}
 			}),
 		);
+	}
+
+	private StopDrag(instant: boolean) {
+		if (instant) {
+			this.handleInner.anchoredPosition = Vector2.zero;
+			this.handleOuterImage.color.a = 0;
+			this.handleInnerImage.color.a = 0;
+			this.handleOuterOutline.color.a = 0;
+		} else {
+			NativeTween.AnchoredPosition(this.handleInner, Vector2.zero, 0.1).SetUseUnscaledTime(true);
+			NativeTween.GraphicAlpha(this.handleOuterImage, 0, 0.2).SetUseUnscaledTime(true);
+			NativeTween.GraphicAlpha(this.handleInnerImage, 0, 0.2).SetUseUnscaledTime(true);
+			NativeTween.GraphicAlpha(this.handleOuterOutline, 0, 0.2).SetUseUnscaledTime(true);
+		}
+		this.input = Vector2.zero;
+		this.dragging = false;
+		this.joystickTouchId = -1;
 	}
 
 	public SetRaycastPadding(padding: Vector4): void {
@@ -105,6 +116,9 @@ export default class DynamicJoystick extends AirshipBehaviour {
 	}
 
 	public SetActive(active: boolean) {
+		if (!active && this.dragging) {
+			this.StopDrag(true);
+		}
 		this.gameObject.SetActive(active);
 	}
 

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/MobileControlsCanvas.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/MobileControlsCanvas.ts
@@ -27,6 +27,23 @@ export default class MobileControlsCanvas extends AirshipBehaviour {
 	private bin = new Bin();
 
 	protected Start(): void {}
+	private canvasEnabled = true;
+
+	protected OnEnable(): void {
+		if (!this.canvasEnabled) {
+			this.canvasEnabled = true;
+			this.SetupEvents();
+		}
+	}
+
+	protected OnDisable(): void {
+		if (this.canvasEnabled) {
+			this.canvasEnabled = false;
+			this.HideCharacterControls();
+			Airship.Characters.localCharacterManager.input?.SetQueuedMoveDirection(new Vector3(0, 0, 0));
+		}
+		this.bin.Clean();
+	}
 
 	public Init(): void {
 		if (!Game.IsMobile()) return;
@@ -39,6 +56,10 @@ export default class MobileControlsCanvas extends AirshipBehaviour {
 		});
 		this.crouchImg = this.crouchGO.GetComponent<Image>()!;
 
+		this.SetupEvents();
+	}
+
+	private SetupEvents() {
 		// Listen for mobile static joystick setting changes
 		this.bin.Add(
 			contextbridge.subscribe("Settings:Loaded", () => {
@@ -76,9 +97,6 @@ export default class MobileControlsCanvas extends AirshipBehaviour {
 				});
 			}),
 		);
-		this.bin.Add(() => {
-			this.HideCharacterControls();
-		});
 	}
 
 	public UpdateButtonState(): void {
@@ -149,9 +167,5 @@ export default class MobileControlsCanvas extends AirshipBehaviour {
 
 			Airship.Characters.localCharacterManager.input?.SetQueuedMoveDirection(new Vector3(input.x, 0, input.y));
 		}
-	}
-
-	protected OnDestroy(): void {
-		this.bin.Clean();
 	}
 }

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/TouchJoystick.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/TouchJoystick.ts
@@ -71,21 +71,25 @@ export default class TouchJoystick extends AirshipBehaviour {
 
 		this.bin.AddEngineEventConnection(
 			CanvasAPI.OnEndDragEvent(this.dragTarget.gameObject, (data) => {
-				this.mobileCameraMovement?.EndDragEvent(data);
-
-				if (this.joystickTouchId === data.pointerId) {
-					NativeTween.GraphicAlpha(this.handleOuterImage, 0.2, 0.2).SetUseUnscaledTime(true);
-					NativeTween.GraphicAlpha(this.handleInnerImage, 0.2, 0.2).SetUseUnscaledTime(true);
-					NativeTween.GraphicAlpha(this.handleOuterOutline, 0.2, 0.2).SetUseUnscaledTime(true);
-					this.input = Vector2.zero;
-					this.dragging = false;
-					this.joystickTouchId = -1;
-
-					// todo: adjust speed by distance
-					NativeTween.AnchoredPosition(this.handleInner, Vector2.zero, 0.1).SetUseUnscaledTime(true);
-				}
+				this.EndDrag(data.pointerId);
 			}),
 		);
+	}
+
+	private EndDrag(pointerId: number) {
+		this.mobileCameraMovement?.EndDragEvent(pointerId);
+
+		if (this.joystickTouchId === pointerId) {
+			NativeTween.GraphicAlpha(this.handleOuterImage, 0.2, 0.2).SetUseUnscaledTime(true);
+			NativeTween.GraphicAlpha(this.handleInnerImage, 0.2, 0.2).SetUseUnscaledTime(true);
+			NativeTween.GraphicAlpha(this.handleOuterOutline, 0.2, 0.2).SetUseUnscaledTime(true);
+			this.input = Vector2.zero;
+			this.dragging = false;
+			this.joystickTouchId = -1;
+
+			// todo: adjust speed by distance
+			NativeTween.AnchoredPosition(this.handleInner, Vector2.zero, 0.1).SetUseUnscaledTime(true);
+		}
 	}
 
 	public SetRaycastPadding(padding: Vector4): void {
@@ -116,6 +120,9 @@ export default class TouchJoystick extends AirshipBehaviour {
 
 	public SetActive(active: boolean) {
 		this.gameObject.SetActive(active);
+		if (!active && this.dragging) {
+			this.EndDrag(this.joystickTouchId);
+		}
 	}
 
 	override OnDestroy(): void {}

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Overlay/MobileCameraMovement.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Overlay/MobileCameraMovement.ts
@@ -44,7 +44,7 @@ export default class MobileCameraMovement extends AirshipBehaviour {
 		);
 		this.bin.AddEngineEventConnection(
 			CanvasAPI.OnEndDragEvent(this.gameObject, (data) => {
-				this.EndDragEvent(data);
+				this.EndDragEvent(data.pointerId);
 			}),
 		);
 	}
@@ -91,8 +91,8 @@ export default class MobileCameraMovement extends AirshipBehaviour {
 		);
 	}
 
-	public EndDragEvent(data: PointerEventData) {
-		if (this.touchPointerId === data.pointerId) {
+	public EndDragEvent(pointerId: number) {
+		if (this.touchPointerId === pointerId) {
 			this.touchPointerId = -1;
 		}
 	}


### PR DESCRIPTION
Hiding mobile inputs now clears the inputs instead of continuing to hold them down. 
You can test in Testbed with this script: 

`import { Airship } from "@Easy/Core/Shared/Airship";

export default class MobileInputTests extends AirshipBehaviour {
	private on = true;
	protected OnEnable(): void {
		this.Tick();
	}

	private Tick() {
		task.delay(3, () => {
			this.on = !this.on;
			Airship.Input.SetMobileButtonsVisibility(this.on);
			this.Tick();
		});
	}
}
`