### PR TITLE
Feature/mobile button disable

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Shared/Character/CharacterConfigSetup.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Character/CharacterConfigSetup.ts
@@ -5,6 +5,7 @@ import { FixedCameraMode } from "../Camera/DefaultCameraModes/FixedCameraMode";
 import { OrbitCameraMode } from "../Camera/DefaultCameraModes/OrbitCameraMode";
 import { Dependency } from "../Flamework";
 import { Game } from "../Game";
+import { CoreMobileButton } from "../Input/Mobile/MobileButton";
 import { InventoryUIVisibility } from "../Inventory/InventoryUIVisibility";
 import { CharacterCameraMode } from "./LocalCharacter/CharacterCameraMode";
 
@@ -158,11 +159,11 @@ export default class CharacterConfigSetup extends AirshipBehaviour {
 			});
 
 			if (!this.enableJumping) {
-				Airship.Input.HideMobileButtons("Jump");
+				Airship.Input.HideMobileButtons(CoreMobileButton.Jump);
 			}
 
 			if (!this.enableCrouching) {
-				Airship.Input.HideMobileButtons("Crouch");
+				Airship.Input.HideMobileButtons(CoreMobileButton.CrouchToggle);
 			}
 		}
 	}

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Input/AirshipInputSingleton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Input/AirshipInputSingleton.ts
@@ -361,8 +361,8 @@ export class AirshipInputSingleton {
 				this.UnregisterAction(actionName);
 			}
 
+			// Disable core mobile buttons if their action is disabled
 			if (Game.IsMobile()) {
-				// Find the CoreMobileButton that corresponds to this CoreAction
 				for (const [, coreMobileButton] of pairs(CoreMobileButton)) {
 					const correspondingCoreAction = CoreMobileButtonToCoreAction[coreMobileButton];
 					if (correspondingCoreAction === actionName) {

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Input/AirshipInputSingleton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Input/AirshipInputSingleton.ts
@@ -19,7 +19,7 @@ import { InputActionEvent } from "./InputActionEvent";
 import { ActionInputType, InputUtil, KeyType, ModifierKey } from "./InputUtil";
 import AirshipMobileButton from "./Mobile/AirshipMobileButton";
 import DynamicJoystick from "./Mobile/DynamicJoystick";
-import { MobileButtonConfig } from "./Mobile/MobileButton";
+import { CoreMobileButton, CoreMobileButtonToCoreAction, MobileButtonConfig } from "./Mobile/MobileButton";
 import MobileControlsCanvas from "./Mobile/MobileControlsCanvas";
 import TouchJoystick from "./Mobile/TouchJoystick";
 import ProximityPrompt from "./ProximityPrompts/ProximityPrompt";
@@ -129,36 +129,6 @@ export class AirshipInputSingleton {
 		// 	}
 		// });
 
-		if (Game.coreContext === CoreContext.GAME && Game.IsGameLuauContext()) {
-			if (Game.IsMobile()) {
-				this.CreateMobileControlCanvas();
-			}
-
-			// A Game keybind was updated from the keybind menu.
-			contextbridge.subscribe(
-				"ProtectedKeybind:Updated",
-				(
-					from: LuauContext,
-					name: string,
-					id: number,
-					isKeyBinding: boolean,
-					key?: Key,
-					modifierKey?: ModifierKey,
-					mouseButton?: MouseButton,
-				) => {
-					if (from !== LuauContext.Protected) return;
-					const matchingGameAction = this.GetActions(name).find((a) => a.id === id);
-					if (!matchingGameAction) return;
-					let binding: Binding | undefined;
-					if (isKeyBinding && key) binding = Binding.Key(key, modifierKey);
-					if (!isKeyBinding && mouseButton !== undefined && mouseButton > -1) {
-						binding = Binding.MouseButton(mouseButton, modifierKey);
-					}
-					if (binding) matchingGameAction.UpdateBinding(binding);
-				},
-			);
-		}
-
 		if (Game.IsProtectedLuauContext()) {
 			contextbridge.subscribe(
 				"ProtectedKeybind:CreateAction",
@@ -223,6 +193,36 @@ export class AirshipInputSingleton {
 
 			this.isSprintToggleSprinting = !this.isSprintToggleSprinting;
 		});
+
+		if (Game.coreContext === CoreContext.GAME && Game.IsGameLuauContext()) {
+			if (Game.IsMobile()) {
+				this.CreateMobileControlCanvas();
+			}
+
+			// A Game keybind was updated from the keybind menu.
+			contextbridge.subscribe(
+				"ProtectedKeybind:Updated",
+				(
+					from: LuauContext,
+					name: string,
+					id: number,
+					isKeyBinding: boolean,
+					key?: Key,
+					modifierKey?: ModifierKey,
+					mouseButton?: MouseButton,
+				) => {
+					if (from !== LuauContext.Protected) return;
+					const matchingGameAction = this.GetActions(name).find((a) => a.id === id);
+					if (!matchingGameAction) return;
+					let binding: Binding | undefined;
+					if (isKeyBinding && key) binding = Binding.Key(key, modifierKey);
+					if (!isKeyBinding && mouseButton !== undefined && mouseButton > -1) {
+						binding = Binding.MouseButton(mouseButton, modifierKey);
+					}
+					if (binding) matchingGameAction.UpdateBinding(binding);
+				},
+			);
+		}
 	}
 
 	/**
@@ -350,6 +350,9 @@ export class AirshipInputSingleton {
 	 */
 	public DisableCoreActions(coreActions: CoreAction[]) {
 		for (const actionName of coreActions) {
+			this.GetActions(actionName).forEach((a) => {
+				a.UnsetBinding();
+			});
 			if (Game.IsGameLuauContext()) {
 				task.defer(() => {
 					contextbridge.broadcast("ProtectedKeybind:UnregisterAction", actionName);
@@ -357,9 +360,16 @@ export class AirshipInputSingleton {
 			} else {
 				this.UnregisterAction(actionName);
 			}
-			this.GetActions(actionName).forEach((a) => {
-				a.UnsetBinding();
-			});
+
+			if (Game.IsMobile()) {
+				// Find the CoreMobileButton that corresponds to this CoreAction
+				for (const [, coreMobileButton] of pairs(CoreMobileButton)) {
+					const correspondingCoreAction = CoreMobileButtonToCoreAction[coreMobileButton];
+					if (correspondingCoreAction === actionName) {
+						this.HideMobileButtons(coreMobileButton);
+					}
+				}
+			}
 		}
 	}
 
@@ -374,6 +384,17 @@ export class AirshipInputSingleton {
 	/** Unregisters an action (removes binding, clears from settings menu) */
 	private UnregisterAction(name: string) {
 		this.actionTable.delete(name.lower());
+	}
+
+	/**
+	 * Checks if a core action is enabled.
+	 *
+	 * @param actionName The name of the action to check
+	 * @returns True if the action is enabled, false otherwise
+	 */
+	public IsCoreActionEnabled(actionName: string): boolean {
+		const actions = this.GetActions(actionName);
+		return actions.some((a) => !a.binding.IsUnset());
 	}
 
 	/**
@@ -549,6 +570,11 @@ export class AirshipInputSingleton {
 		mobileButtonsForAction.push(mobileButton);
 		this.actionToMobileButtonTable.set(lowerName, mobileButtonsForAction);
 
+		const isCoreAction = CoreMobileButtonToCoreAction[actionName as CoreMobileButton];
+		if (isCoreAction && !this.IsCoreActionEnabled(isCoreAction)) {
+			mobileButton.SetActive(false);
+		}
+
 		return mobileButton;
 	}
 
@@ -651,7 +677,7 @@ export class AirshipInputSingleton {
 	}
 
 	/**
-	 * Hides all mobile buttons that trigger the action `name`.
+	 * Shows all mobile buttons that trigger the action `name`.
 	 *
 	 * @param name An action name.
 	 */

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/AirshipMobileButton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/AirshipMobileButton.ts
@@ -4,6 +4,14 @@ export default class AirshipMobileButton extends AirshipButton {
 	/** The icon of this mobile button */
 	@Header("Mobile Button")
 	public iconImage: Image;
+	private startingImageAlpha: number;
+	private startingIconAlpha: number;
+
+	override Start(): void {
+		super.Start();
+		this.startingImageAlpha = this.image?.color.a ?? 1;
+		this.startingIconAlpha = this.iconImage.color.a;
+	}
 
 	public SetIconFromSprite(sprite: Sprite) {
 		this.iconImage.sprite = sprite;
@@ -11,5 +19,19 @@ export default class AirshipMobileButton extends AirshipButton {
 
 	public SetIconFromTexture(texture: Texture2D) {
 		this.iconImage.sprite = Bridge.MakeDefaultSprite(texture);
+	}
+
+	public FadeOut(duration: number = 0.5): void {
+		if (this.image && this.iconImage) {
+			NativeTween.GraphicAlpha(this.image, 0, duration).SetUseUnscaledTime(true);
+			NativeTween.GraphicAlpha(this.iconImage, 0, duration).SetUseUnscaledTime(true);
+		}
+	}
+
+	public FadeIn(duration: number = 0.5): void {
+		if (this.image && this.iconImage && this.startingImageAlpha && this.startingIconAlpha) {
+			NativeTween.GraphicAlpha(this.image, this.startingImageAlpha, duration).SetUseUnscaledTime(true);
+			NativeTween.GraphicAlpha(this.iconImage, this.startingIconAlpha, duration).SetUseUnscaledTime(true);
+		}
 	}
 }

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/MobileButton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/MobileButton.ts
@@ -1,3 +1,5 @@
+import { CoreAction } from "../AirshipCoreAction";
+
 export interface MobileButtonConfig {
 	/**
 	 * A path to an image.
@@ -28,3 +30,9 @@ export enum CoreMobileButton {
 	CrouchToggle = "CrouchToggle",
 	SprintToggle = "SprintToggle",
 }
+
+export const CoreMobileButtonToCoreAction = {
+	[CoreMobileButton.Jump]: CoreAction.Jump,
+	[CoreMobileButton.CrouchToggle]: CoreAction.Crouch,
+	[CoreMobileButton.SprintToggle]: CoreAction.Sprint,
+};

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/MobileControlsCanvas.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/MobileControlsCanvas.ts
@@ -115,6 +115,11 @@ export default class MobileControlsCanvas extends AirshipBehaviour {
 		}
 	}
 
+	/**
+	 * Shows all character control UI elements for mobile devices.
+	 * This includes activating the appropriate joystick and making
+	 * core mobile buttons that aren't disabled visible.
+	 */
 	public ShowCharacterControls(): void {
 		if (this.isJoystickDynamic) {
 			this.dynamicJoystick.gameObject.SetActive(true);
@@ -132,6 +137,11 @@ export default class MobileControlsCanvas extends AirshipBehaviour {
 		}
 	}
 
+	/**
+	 * Hides all character control UI elements for mobile devices.
+	 * This includes deactivating both joystick types and making
+	 * core mobile buttons that aren't disabled invisible.
+	 */
 	public HideCharacterControls(): void {
 		this.staticJoystick.gameObject.SetActive(false);
 		this.dynamicJoystick.gameObject.SetActive(false);

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/MobileControlsCanvas.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/MobileControlsCanvas.ts
@@ -4,8 +4,9 @@ import { Game } from "../../Game";
 import { ColorUtil } from "../../Util/ColorUtil";
 import { CoreAction } from "../AirshipCoreAction";
 import { CoreIcon } from "../UI/CoreIcon";
+import AirshipMobileButton from "./AirshipMobileButton";
 import DynamicJoystick from "./DynamicJoystick";
-import { CoreMobileButton } from "./MobileButton";
+import { CoreMobileButton, CoreMobileButtonToCoreAction } from "./MobileButton";
 import TouchJoystick from "./TouchJoystick";
 
 export default class MobileControlsCanvas extends AirshipBehaviour {
@@ -122,7 +123,12 @@ export default class MobileControlsCanvas extends AirshipBehaviour {
 		}
 
 		for (const [, button] of pairs(CoreMobileButton)) {
-			Airship.Input.ShowMobileButtons(button);
+			if (Airship.Input.IsCoreActionEnabled(CoreMobileButtonToCoreAction[button])) {
+				const buttons = Airship.Input.GetMobileButtons(button);
+				for (const button of buttons) {
+					button.GetAirshipComponent<AirshipMobileButton>()?.FadeIn();
+				}
+			}
 		}
 	}
 
@@ -131,7 +137,10 @@ export default class MobileControlsCanvas extends AirshipBehaviour {
 		this.dynamicJoystick.gameObject.SetActive(false);
 
 		for (const [, button] of pairs(CoreMobileButton)) {
-			Airship.Input.HideMobileButtons(button);
+			const buttons = Airship.Input.GetMobileButtons(button);
+			for (const button of buttons) {
+				button.GetAirshipComponent<AirshipMobileButton>()?.FadeOut();
+			}
 		}
 	}
 

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/AirshipButton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/AirshipButton.ts
@@ -7,7 +7,7 @@ export default class AirshipButton extends AirshipBehaviour {
 	private bin = new Bin();
 
 	private disabled = false;
-	private image: Image | undefined;
+	protected image: Image | undefined;
 	public button!: Button;
 	private startingColor: Color | undefined;
 	private loading = false;
@@ -113,7 +113,7 @@ export default class AirshipButton extends AirshipBehaviour {
 
 	public SetStartingScale(scale: Vector3): void {
 		this.startingScale = scale;
-		if (this.enabled)  this.transform.localScale = scale;
+		if (this.enabled) this.transform.localScale = scale;
 	}
 
 	protected OnEnable(): void {


### PR DESCRIPTION
Have core buttons visible change if developer uses
```Airship.Input.DisableCoreActions()```
or
```Airship.Input.HideMobileButtons()```
in a start function from a manager script

* Added fade out and fade in function for mobile buttons
* Controls Canvas fades out/in buttons when the character dies/respawns
* Character config now properly hides buttons if their variables are set

Did not make any edits to the ShowMobileButtons or HideMobileButtons this time around.