### PR TITLE
Fix some signal method behavior during fire

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Shared/Util/Signal.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Util/Signal.ts
@@ -1,4 +1,5 @@
 import { Cancellable } from "./Cancellable";
+import { MapUtil } from "./MapUtil";
 
 type SignalParams<T> = Parameters<
 	[T] extends [unknown[]] ? (...args: T) => never : [T] extends [unknown] ? (arg: T) => never : () => never
@@ -47,6 +48,11 @@ export class Signal<T extends unknown[] | unknown = void> {
 	private allowYielding = false;
 	private keys: number[] = [];
 	private readonly connections: Map<number, Array<CallbackItem<T>>> = new Map();
+	/**
+	 * Map from priority to all callbacks queued at that priority. Holds connections
+	 * that were registered while this signal was firing (to be added after fire completes).
+	 */
+	private queuedConnections = new Map<number, CallbackItem<T>[]>();
 	public debugGameObject = false;
 	public isDestroyed = false;
 
@@ -91,9 +97,8 @@ export class Signal<T extends unknown[] | unknown = void> {
 		const item: CallbackItem<T> = [callback, true];
 
 		if (this.firing) {
-			task.defer(() => {
-				this.AddConnection(priority, item);
-			});
+			const queuedConns = MapUtil.GetOrCreate(this.queuedConnections, priority, []);
+			queuedConns.push(item);
 		} else {
 			this.AddConnection(priority, item);
 		}
@@ -216,6 +221,13 @@ export class Signal<T extends unknown[] | unknown = void> {
 		}
 
 		this.firing = false;
+
+		// Register all queued connections during previous fire
+		for (const [priority, connections] of this.queuedConnections) {
+			for (const connection of connections) {
+				this.AddConnection(priority, connection);
+			}
+		}
 
 		return args[0] as T;
 	}

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Util/Signal.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Util/Signal.ts
@@ -222,7 +222,7 @@ export class Signal<T extends unknown[] | unknown = void> {
 
 		this.firing = false;
 
-		// Register all queued connections during previous fire
+		// Register all queued connections during fire
 		for (const [priority, connections] of this.queuedConnections) {
 			for (const connection of connections) {
 				this.AddConnection(priority, connection);

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Util/Signal.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Util/Signal.ts
@@ -114,7 +114,7 @@ export class Signal<T extends unknown[] | unknown = void> {
 
 			const itemIdx = items.indexOf(item);
 			if (itemIdx !== -1) {
-				items.unorderedRemove(itemIdx);
+				items.remove(itemIdx);
 
 				if (items.size() === 0) {
 					this.connections.delete(priority);

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Util/Signal.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Util/Signal.ts
@@ -53,6 +53,11 @@ export class Signal<T extends unknown[] | unknown = void> {
 	 * that were registered while this signal was firing (to be added after fire completes).
 	 */
 	private queuedConnections = new Map<number, CallbackItem<T>[]>();
+	/**
+	 * This flag is to safely handle DisconnectAll while firing. When enabled we stop
+	 * looping callbacks for the current Fire.
+	 */
+	private disconnectAllRequested = false;
 	public debugGameObject = false;
 	public isDestroyed = false;
 
@@ -124,8 +129,16 @@ export class Signal<T extends unknown[] | unknown = void> {
 		return () => {
 			if (!item[1]) return;
 			if (this.firing) {
+				// Mark as disconnected and cleanup later
 				item[1] = false;
 				task.defer(disconnect);
+
+				// Clear from queued connections
+				const queuedConnectionsAtPriority = this.queuedConnections.get(priority);
+				if (queuedConnectionsAtPriority) {
+					const queuedIdx = queuedConnectionsAtPriority.indexOf(item);
+					if (queuedIdx >= 0) queuedConnectionsAtPriority.remove(queuedIdx);
+				}
 			} else {
 				disconnect();
 			}
@@ -210,26 +223,36 @@ export class Signal<T extends unknown[] | unknown = void> {
 						break;
 					}
 				}
+
+				// Cancel fire when DisconnectAll is requested
+				if (this.disconnectAllRequested) break;
 			}
-			if (cancelled) {
-				break;
-			}
+			if (cancelled) break;
+			// Cancel fire when DisconnectAll is requested
+			if (this.disconnectAllRequested) break;
 		}
 
 		if (this.debugLogging) {
 			print("fire count: " + fireCount);
 		}
 
+		// Reset
+		this.disconnectAllRequested = false;
 		this.firing = false;
 
-		// Register all queued connections during fire
+		this.RegisterQueuedConnections();
+
+		return args[0] as T;
+	}
+
+	/** Register all queued connections during fire */
+	private RegisterQueuedConnections() {
 		for (const [priority, connections] of this.queuedConnections) {
 			for (const connection of connections) {
 				this.AddConnection(priority, connection);
 			}
 		}
-
-		return args[0] as T;
+		this.queuedConnections.clear();
 	}
 
 	/**
@@ -259,15 +282,11 @@ export class Signal<T extends unknown[] | unknown = void> {
 	 * Clears all connections.
 	 */
 	public DisconnectAll() {
-		if (this.firing) {
-			task.defer(() => {
-				this.connections.clear();
-				this.keys.clear();
-			});
-		} else {
-			this.connections.clear();
-			this.keys.clear();
-		}
+		if (this.firing) this.disconnectAllRequested = true;
+
+		this.connections.clear();
+		this.keys.clear();
+		this.queuedConnections.clear();
 	}
 
 	/**


### PR DESCRIPTION
All signal methods need to handle the case of being run while the signal is firing. This changes from defering updates (which can have unpredictable behavior) to queueing updates and handling immediately after Fire() completes.

Additional opinionated change snuck in: changed items.unorderedRemove to items.remove when disconnecting a signal. This is slower but upholds what I feel is an implicit promise that connections at the same priority are prioritized by registration time. That should only effect performance in signals with very large connection counts. In that case this is worse behavior, but I anticipate it might save people from running into bugs based on an expectation of how connections are ordered..