### PR TITLE
Add API to skip loading screen + player flags

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Shared/Game.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Game.ts
@@ -9,6 +9,7 @@ import { Signal } from "./Util/Signal";
 // Declared here to avoid another global type that starts with "Airship"
 declare var AirshipConst: {
 	playerVersion: number;
+	playerFlags: string[]
 };
 
 const platform = Application.platform;
@@ -80,6 +81,8 @@ export class Game {
 	 * The local player's client version number.
 	 */
 	public static playerVersion = 16;
+	/** List of Airship client feature flags enabled on this player. */
+	public static playerFlags = new Set<string>();
 
 	public static startingScene = Bridge.GetActiveScene();
 
@@ -245,6 +248,7 @@ export class Game {
 // try catch for prev version support
 try {
 	Game.playerVersion = AirshipConst.playerVersion;
+	Game.playerFlags = new Set(AirshipConst.playerFlags);
 } catch (err) {}
 
 if (Game.IsGameLuauContext()) {

--- a/Assets/AirshipPackages/@Easy/Core/Shared/LoadingScreen/LoadingScreenSingleton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/LoadingScreen/LoadingScreenSingleton.ts
@@ -4,7 +4,6 @@ import { Singleton } from "@Easy/Core/Shared/Flamework";
 import { Game } from "@Easy/Core/Shared/Game";
 import { Mouse } from "@Easy/Core/Shared/UserInput";
 import { Bin } from "@Easy/Core/Shared/Util/Bin";
-import { OnUpdate } from "../Util/Timer";
 
 /**
  * [Client only]
@@ -36,7 +35,7 @@ export class LoadingScreenSingleton {
 			this.loadingBin.Add(Mouse.AddUnlocker());
 		});
 
-		OnUpdate.Once(() => {
+		task.delay(0, () => {
 			if (!this.hasUsed) {
 				this.FinishLoading();
 			}
@@ -54,6 +53,38 @@ export class LoadingScreenSingleton {
 		this.hasUsed = true;
 		this.coreLoadingScreen!.updatedByGame = true;
 		this.coreLoadingScreen!.SetProgress(step, 50 + progress / 2);
+	}
+
+	/**
+	 * Shows skip button on the loading screen in case a loading step is optional (for example: warming shaders).
+	 * When clicked IsSkipRequested will return true once.
+	 */
+	public ShowSkipButton(): void {
+		if (!Game.playerFlags.has("SkipLoading")) return;
+
+		this.coreLoadingScreen?.SetSkipButtonShown(true);
+	}
+
+	/**
+	 * Hides skip button.
+	 */
+	public HideSkipButton(): void {
+		if (!Game.playerFlags.has("SkipLoading")) return;
+
+		this.coreLoadingScreen?.SetSkipButtonShown(false);
+	}
+
+	/**
+	 * Returns true one time if the client requests a skip. Won't return true again until the client next
+	 * requests a skip.
+	 */
+	public IsSkipRequested(): boolean {
+		if (!Game.playerFlags.has("SkipLoading")) return false;
+		if (!this.coreLoadingScreen) return false;
+
+		const requested = this.coreLoadingScreen.skipRequested;
+		if (requested) this.coreLoadingScreen.skipRequested = false;
+		return requested;
 	}
 
 	/**

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Types/Generated.d.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Types/Generated.d.ts
@@ -27729,6 +27729,8 @@ interface CoreLoadingScreen extends BundleLoadingScreen {
     progressText: TMP_Text;
     disconnectButton: Button;
     continueButton: Button;
+    skipText: TMP_Text;
+    skipButton: Button;
     spinner: GameObject;
     gameImage: RawImage;
     editorGameImageColor: Color;
@@ -27737,6 +27739,7 @@ interface CoreLoadingScreen extends BundleLoadingScreen {
     errorText: TMP_Text;
     voiceChatCard: RectTransform;
     voiceChatToggle: InternalToggle;
+    skipRequested: boolean;
     updatedByGame: boolean;
 
 
@@ -27748,7 +27751,9 @@ interface CoreLoadingScreen extends BundleLoadingScreen {
     RetryBtn_OnClick(): void;
     SetError(msg: string): void;
     SetProgress(text: string, percent: number): void;
+    SetSkipButtonShown(shown: boolean): void;
     SetTotalDownloadSize(sizeBytes: number): void;
+    SkipBtn_OnClick(): void;
 
 
 }

--- a/Assets/Code/LoadingScreen.meta
+++ b/Assets/Code/LoadingScreen.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d6e81ae2fe2854249800b4bbbec395f7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Code/LoadingScreen/LoadingScreenTest.ts
+++ b/Assets/Code/LoadingScreen/LoadingScreenTest.ts
@@ -1,0 +1,16 @@
+import { Airship } from "@Easy/Core/Shared/Airship";
+
+export default class LoadingScreenTest extends AirshipBehaviour {
+	override Start(): void {
+		Airship.LoadingScreen.SetProgress("Big Wait", 0.1);
+
+		task.wait(3);
+		
+		Airship.LoadingScreen.ShowSkipButton();
+		while (task.wait()) {
+			if (Airship.LoadingScreen.IsSkipRequested()) break;
+		}
+
+		Airship.LoadingScreen.FinishLoading();
+	}
+}

--- a/Assets/Code/LoadingScreen/LoadingScreenTest.ts.meta
+++ b/Assets/Code/LoadingScreen/LoadingScreenTest.ts.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: a24535ed1e4ba4727b40da1bde277a3a
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: c4bd260abc8845c88b54ec021581f2a0, type: 3}


### PR DESCRIPTION
Allows game to present option for player to skip loading screen.

Depends on https://github.com/easy-games/airship/pull/541 but should run without error without it.

Open to rethink API if anyone has better ideas.

Example:
```ts
	override Start(): void {
		Airship.LoadingScreen.SetProgress("Big Wait", 0.1);

		task.wait(3);
		
		Airship.LoadingScreen.ShowSkipButton();
		while (task.wait()) {
			if (Airship.LoadingScreen.IsSkipRequested()) break;
		}

		Airship.LoadingScreen.FinishLoading();
	}
```
https://github.com/user-attachments/assets/938af9b8-0db1-4930-a403-9c73ebd5433e

