### PR TITLE
Fix: Proximity Prompt Controller illegal arithemtic sub

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Client/Controllers/ProximityPrompt/ProximityPromptController.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Client/Controllers/ProximityPrompt/ProximityPromptController.ts
@@ -67,6 +67,9 @@ export class ProximityPromptController {
 
 				let possiblePrompts = new Map<string, ProximityPrompt[]>();
 				for (let prompt of this.allPrompts) {
+					const promptPosition = prompt.GetPosition();
+					if (!promptPosition) continue;
+
 					// If the player is dead and prompt is set to hide when dead, skip getting new prompts
 					if (Game.localPlayer.character?.IsDead() && prompt.hideWhenDead) continue;
 
@@ -76,7 +79,7 @@ export class ProximityPromptController {
 						promptActionMap.set(prompt.actionName, [prompt]);
 					}
 
-					const distToPrompt = localCharacterPosition.sub(prompt.GetPosition()).magnitude;
+					const distToPrompt = localCharacterPosition.sub(promptPosition).magnitude;
 					if (distToPrompt > prompt.maxRange) continue;
 
 					const actionPrompts = MapUtil.GetOrCreate(possiblePrompts, prompt.actionName, []);


### PR DESCRIPTION
Every proximity prompt in the world will stop working until I rejoin. This is because the client prompt controller crashes whenever it encounters a prompt without a position.

Error:
<img width="848" height="245" alt="image" src="https://github.com/user-attachments/assets/69050412-f2c0-4218-a2d7-0fab3e05abaa" />

Fix:
<img width="978" height="371" alt="image" src="https://github.com/user-attachments/assets/42fe21b9-0e26-4b4b-9660-0d0b7fa6866f" />
