### PR TITLE
Fixed "Invisible Wall" Grounded issue

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Prefabs/Character/AirshipCharacter.prefab
+++ b/Assets/AirshipPackages/@Easy/Core/Prefabs/Character/AirshipCharacter.prefab
@@ -981,7 +981,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterHeight: 1.8
   characterRadius: 0.2
-  colliderGroundOffset: 0.015
+  colliderGroundOffset: 0.05
   onlySprintForward: 0
   useAccelerationMovement: 0
   speed: 4.666667
@@ -1002,10 +1002,7 @@ MonoBehaviour:
   allowDebugFlying: 1
   flySpeedMultiplier: 3
   verticalFlySpeed: 2
-  jumpUpBlockCooldown: 0.4
   useGravity: 1
-  useGravityWhileGrounded: 0
-  alwaysSnapToGround: 0
   gravityMultiplier: 5
   upwardsGravityMultiplier: 1
   groundCollisionLayerMask:
@@ -1021,7 +1018,6 @@ MonoBehaviour:
   additionalNoInputDrag: 3
   airInputAcceleration: 60
   detectStepUps: 1
-  alwaysStepUp: 0
   assistedLedgeJump: 1
   maxStepUpHeight: 0.3
   stepUpRampDistance: 0.75

--- a/Assets/AirshipPackages/@Easy/Core/Prefabs/Character/AirshipCharacter.prefab
+++ b/Assets/AirshipPackages/@Easy/Core/Prefabs/Character/AirshipCharacter.prefab
@@ -959,7 +959,7 @@ MonoBehaviour:
   correctionInterpTime: 0.1
   correctionMaxMagnitude: 10
   autoCalibrateSkiddingSpeed: 1
-  smoothedRotationSpeed: 450
+  smoothedRotationSpeed: 550
   rotateAutomatically: 1
   rotateHeadToLookVector: 1
   lookVectorInfluence: 0.4

--- a/Assets/AirshipPackages/@Easy/Core/Prefabs/Character/AirshipCharacter.prefab
+++ b/Assets/AirshipPackages/@Easy/Core/Prefabs/Character/AirshipCharacter.prefab
@@ -959,7 +959,7 @@ MonoBehaviour:
   correctionInterpTime: 0.1
   correctionMaxMagnitude: 10
   autoCalibrateSkiddingSpeed: 1
-  smoothedRotationSpeed: 550
+  smoothedRotationSpeed: 450
   rotateAutomatically: 1
   rotateHeadToLookVector: 1
   lookVectorInfluence: 0.4


### PR DESCRIPTION
The problem was the the movement collider could clip the edges of floor colliders. This issue was masked by the "Always snap to ground" flag so it re-appeared when that flag was disabled.

This branch
- Makes the forward raycasts on the character use the "colliderGroundMargin" value
- Increases movement colliders "colliderGroundMargin" to avoid precision errors on planar ground colliders
- Removes unused / unneeded movement settings (jumpUpBlockCooldown, useGravityWhileGrounded, alwaySnapToGround, alwaysStepUp)