### PR TITLE
Feat: Add Category option to Airship.Settings

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Prefabs/MainMenu/SettingsPage/SettingsCategory.prefab
+++ b/Assets/AirshipPackages/@Easy/Core/Prefabs/MainMenu/SettingsPage/SettingsCategory.prefab
@@ -1,0 +1,385 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3401028466696489110
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8411611596044024331}
+  - component: {fileID: 805865245704857705}
+  - component: {fileID: 7977565362851267800}
+  - component: {fileID: 1760667719916339594}
+  m_Layer: 5
+  m_Name: CategoryHeader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8411611596044024331
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3401028466696489110}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8336402165095103525}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &805865245704857705
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3401028466696489110}
+  m_CullTransparentMesh: 1
+--- !u!114 &7977565362851267800
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3401028466696489110}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: CATEGORY LABEL
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8d354403cbae24e3dadadced631ed91a, type: 2}
+  m_sharedMaterial: {fileID: 4646554452606745, guid: 8d354403cbae24e3dadadced631ed91a, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &1760667719916339594
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3401028466696489110}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: 1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &5258693307106077007
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4771338886207331822}
+  - component: {fileID: 5431937908972973124}
+  - component: {fileID: 8679997919278140506}
+  m_Layer: 5
+  m_Name: Spacer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4771338886207331822
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5258693307106077007}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8336402165095103525}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 15}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5431937908972973124
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5258693307106077007}
+  m_CullTransparentMesh: 1
+--- !u!114 &8679997919278140506
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5258693307106077007}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6535133029163651272
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8336402165095103525}
+  - component: {fileID: 3125919504362925191}
+  - component: {fileID: 7124858406499082076}
+  - component: {fileID: 4251658310352369550}
+  - component: {fileID: 7679109609369445436}
+  - component: {fileID: 2584568608134013358}
+  m_Layer: 5
+  m_Name: SettingsCategory
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8336402165095103525
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6535133029163651272}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4771338886207331822}
+  - {fileID: 8411611596044024331}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 643.5, y: -41}
+  m_SizeDelta: {x: 1257, y: 0}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &3125919504362925191
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6535133029163651272}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 2
+  m_Spacing: 2
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!222 &7124858406499082076
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6535133029163651272}
+  m_CullTransparentMesh: 1
+--- !u!114 &4251658310352369550
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6535133029163651272}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 0
+  m_VerticalFit: 2
+--- !u!114 &7679109609369445436
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6535133029163651272}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 2
+--- !u!114 &2584568608134013358
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6535133029163651272}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fa4feffba88dce746a2607f0ec6233b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  guid: 9f019ad3-b6f9-424d-b3bd-436d0af2b209
+  script: {fileID: -4470926828527751678, guid: 8706c7ad2b9aaea45a2bedf165940e1e, type: 3}
+  scriptPath: Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Settings/Controls/SettingsCategory.lua
+  forceContext: 0
+  metadata:
+    name: SettingsCategory
+    singleton: 0
+    decorators: []
+    properties:
+    - name: titleText
+      type: object
+      objectType: TMP_Text
+      items:
+        type: 
+        objectType: 
+        serializedItems: []
+        objectRefs: []
+      refPath: 
+      fileRef: 
+      jsDocs:
+        text: []
+        tags: []
+      decorators: []
+      nullable: 0
+      serializedValue: 
+      serializedObject: {fileID: 7977565362851267800}
+      modified: 1
+    displayIcon: {fileID: 0}
+    displayName: 

--- a/Assets/AirshipPackages/@Easy/Core/Prefabs/MainMenu/SettingsPage/SettingsCategory.prefab.meta
+++ b/Assets/AirshipPackages/@Easy/Core/Prefabs/MainMenu/SettingsPage/SettingsCategory.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 096927f0c442a5c4f96e45ce3a399204
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AirshipPackages/@Easy/Core/Prefabs/MainMenu/SettingsPage/SettingsPage.prefab
+++ b/Assets/AirshipPackages/@Easy/Core/Prefabs/MainMenu/SettingsPage/SettingsPage.prefab
@@ -5248,6 +5248,24 @@ MonoBehaviour:
       serializedValue: 
       serializedObject: {fileID: 1379165800388771806}
       modified: 1
+    - name: categoryPrefab
+      type: object
+      objectType: GameObject
+      items:
+        type: 
+        objectType: 
+        serializedItems: []
+        objectRefs: []
+      refPath: 
+      fileRef: 
+      jsDocs:
+        text: []
+        tags: []
+      decorators: []
+      nullable: 0
+      serializedValue: 
+      serializedObject: {fileID: 6535133029163651272, guid: 096927f0c442a5c4f96e45ce3a399204, type: 3}
+      modified: 1
     displayIcon: {fileID: 0}
     displayName: 
 --- !u!114 &2627436865825335969

--- a/Assets/AirshipPackages/@Easy/Core/Prefabs/MainMenu/SettingsPage/SettingsToggle.prefab
+++ b/Assets/AirshipPackages/@Easy/Core/Prefabs/MainMenu/SettingsPage/SettingsToggle.prefab
@@ -36,7 +36,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: -7}
-  m_SizeDelta: {x: 146.32, y: 30}
+  m_SizeDelta: {x: 154.95, y: 30}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &6966837405641051170
 CanvasRenderer:
@@ -228,16 +228,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fa4feffba88dce746a2607f0ec6233b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  scriptFile: {fileID: 8698240206822664949, guid: a822c156012ca4ec096f55c4f1a07501, type: 3}
-  m_fileFullPath: Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Settings/Controls/SettingsToggle.lua
-  m_error: 0
-  m_yielded: 0
-  m_canResume: 0
-  m_asyncYield: 0
-  m_onUpdateHandle: -1
-  m_onLateUpdateHandle: -1
-  m_shortFileName: 
-  m_metadata:
+  guid: c79541f4-e704-41f6-a47f-e1af747fb32a
+  script: {fileID: 8698240206822664949, guid: a822c156012ca4ec096f55c4f1a07501, type: 3}
+  scriptPath: Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Settings/Controls/SettingsToggle.lua
+  forceContext: 0
+  metadata:
     name: SettingsToggle
     singleton: 0
     decorators: []
@@ -252,6 +247,9 @@ MonoBehaviour:
         objectRefs: []
       refPath: 
       fileRef: AirshipPackages/@Easy/Core/Shared/MainMenu/Components/AirshipToggle.ts
+      jsDocs:
+        text: []
+        tags: []
       decorators: []
       nullable: 0
       serializedValue: 
@@ -267,6 +265,9 @@ MonoBehaviour:
         objectRefs: []
       refPath: 
       fileRef: 
+      jsDocs:
+        text: []
+        tags: []
       decorators: []
       nullable: 0
       serializedValue: 
@@ -274,7 +275,6 @@ MonoBehaviour:
       modified: 1
     displayIcon: {fileID: 0}
     displayName: 
-  contextOverwritten: 0
 --- !u!1 &7036364850923834808
 GameObject:
   m_ObjectHideFlags: 0
@@ -322,7 +322,7 @@ PrefabInstance:
     - target: {fileID: 423383805372366, guid: af684300ee43c4ea08781c5e262dde25, type: 3}
       propertyPath: m_Material
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 2100000, guid: 517dcfc7bf08549efa5108b97eb2e6cc, type: 2}
     - target: {fileID: 1146958252955428272, guid: af684300ee43c4ea08781c5e262dde25, type: 3}
       propertyPath: m_Name
       value: AirshipToggle
@@ -330,7 +330,7 @@ PrefabInstance:
     - target: {fileID: 3064494543369037050, guid: af684300ee43c4ea08781c5e262dde25, type: 3}
       propertyPath: m_Material
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 2100000, guid: 517dcfc7bf08549efa5108b97eb2e6cc, type: 2}
     - target: {fileID: 5338058208321882734, guid: af684300ee43c4ea08781c5e262dde25, type: 3}
       propertyPath: m_Pivot.x
       value: 1

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Settings/Controls/SettingsCategory.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Settings/Controls/SettingsCategory.ts
@@ -1,0 +1,15 @@
+import { Bin } from "@Easy/Core/Shared/Util/Bin";
+
+export default class SettingsCategory extends AirshipBehaviour {
+	public titleText: TMP_Text;
+
+	private bin = new Bin();
+
+	public Init(title: string): void {
+		this.titleText.text = title;
+	}
+
+	override OnDestroy(): void {
+		this.bin.Clean();
+	}
+}

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Settings/Controls/SettingsCategory.ts.meta
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Settings/Controls/SettingsCategory.ts.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8706c7ad2b9aaea45a2bedf165940e1e
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: c4bd260abc8845c88b54ec021581f2a0, type: 3}
+  icon: {instanceID: 0}

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Settings/SettingsPage.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Components/Settings/SettingsPage.ts
@@ -15,6 +15,7 @@ import SettingsSlider from "./Controls/SettingsSlider";
 import SettingsToggle from "./Controls/SettingsToggle";
 import { SettingsTab } from "./SettingsPageName";
 import SettingsSidebar from "./SettingsSidebar";
+import SettingsCategory from "./Controls/SettingsCategory";
 
 const MOBILE_NAV_HEIGHT = 60;
 
@@ -60,6 +61,7 @@ export default class SettingsPage extends AirshipBehaviour {
 	public sliderPrefab: GameObject;
 	public togglePrefab: GameObject;
 	public spacerPrefab: GameObject;
+	public categoryPrefab: GameObject;
 
 	@Header("Pages")
 	public microphonePage: GameObject;
@@ -275,6 +277,15 @@ export default class SettingsPage extends AirshipBehaviour {
 							Protected.Settings.SetGameSetting(setting.name, val);
 						}),
 					);
+				}
+
+				// Category
+				if (gameSetting.type === InternalGameSettingType.Category) {
+					const setting = gameSetting as InternalGameSetting;
+					const go = Object.Instantiate(this.categoryPrefab, this.gamePageSettingsContainer);
+					const categoryComp = go.GetAirshipComponent<SettingsCategory>()!;
+
+					categoryComp.Init(setting.name);
 				}
 			}
 		}

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Singletons/Settings/InternalGameSetting.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Singletons/Settings/InternalGameSetting.ts
@@ -1,6 +1,7 @@
 export enum InternalGameSettingType {
 	Slider = "Slider",
 	Toggle = "Toggle",
+	Category = "Category"
 }
 
 export interface InternalGameSetting {

--- a/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Singletons/Settings/ProtectedSettingsSingleton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/MainMenu/Singletons/Settings/ProtectedSettingsSingleton.ts
@@ -179,6 +179,22 @@ export class ProtectedSettingsSingleton {
 			this.gameSettingsOrdered.push("space");
 		});
 
+		/** *********** **/
+		contextbridge.callback("Settings:AddCategory", (from: LuauContext, name: string) => {
+			if (this.gameSettings.has(name)) {
+				error(`A category named "${name}" already exists.`);
+			}
+
+			const setting: InternalGameSetting = {
+				name,
+				type: InternalGameSettingType.Category,
+				value: name,
+			};
+
+			// this.gameSettingsOrdered.push("space");
+			this.gameSettingsOrdered.push(setting);
+		});
+
 		// Screenshot:
 		Keyboard.OnKeyDown(Key.F2, (event) => {
 			if (event.uiProcessed) return;

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Settings/AirshipSettingsSingleton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Settings/AirshipSettingsSingleton.ts
@@ -84,4 +84,12 @@ export class AirshipSettingsSingleton {
 	public AddSpacer(): void {
 		contextbridge.invoke("Settings:AddSpacer", LuauContext.Protected);
 	}
+
+	/**
+	 * Adds a title and spacer to the settings menu.
+	 * @param name The name of the settings category
+	 */
+	public AddCategory(name: string): void {
+		contextbridge.invoke("Settings:AddCategory", LuauContext.Protected, name);
+	}
 }

--- a/Assets/Code/Examples/SettingsCategoryTest.ts
+++ b/Assets/Code/Examples/SettingsCategoryTest.ts
@@ -1,0 +1,13 @@
+import { Airship } from "@Easy/Core/Shared/Airship";
+
+export default class SettingsCategoryTest extends AirshipSingleton {
+    override Start(): void {
+        Airship.Settings.AddCategory("Test Category");
+        Airship.Settings.AddSlider("Test Slider", 50, 0, 100, 1);
+        Airship.Settings.AddToggle("Test Toggle", true);
+        
+        Airship.Settings.AddCategory("Another Category");
+        Airship.Settings.AddSlider("Another Slider", 50, 0, 100, 1);
+        Airship.Settings.AddToggle("Another Toggle", true);
+    }
+};


### PR DESCRIPTION
Adds `Airship.Settings.AddCategory(title: string)`. Example code in `Code/Examples/SettingsCategoryTest.ts`.

<img width="545" height="279" alt="image" src="https://github.com/user-attachments/assets/f298d28c-bf88-4334-9152-e69ae5bb2f50" />