### PR TITLE
Use fractional input for moveDir

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Shared/Character/LocalCharacter/CharacterInput.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Character/LocalCharacter/CharacterInput.ts
@@ -19,7 +19,6 @@ export class CharacterInput {
 	/** If true holding the sprint key will not result in sprinting */
 	private blockSprint = false;
 
-	private clearQueueNextFrame = false;
 	private queuedMoveDirections: { direction: Vector3; dt: number }[] = [];
 
 	constructor(private readonly character: Character) {
@@ -52,7 +51,7 @@ export class CharacterInput {
 	}
 
 	public SetQueuedMoveDirection(dir: Vector3): void {
-		this.queuedMoveDirections.push({ direction: dir, dt: Time.deltaTime });
+		this.queuedMoveDirections.push({ direction: dir, dt: Time.unscaledDeltaTime });
 	}
 
 	/** Returns `true` if the Humanoid Driver is enabled. */
@@ -104,35 +103,22 @@ export class CharacterInput {
 				const forward = w === s ? 0 : w ? 1 : -1;
 				const sideways = d === a ? 0 : d ? 1 : -1;
 
-				if (this.clearQueueNextFrame) {
-					this.queuedMoveDirections.clear();
-					this.clearQueueNextFrame = false;
-				}
-				this.queuedMoveDirections.push({ direction: new Vector3(sideways, 0, forward), dt });
+				this.queuedMoveDirections.push({ direction: new Vector3(sideways, 0, forward), dt: Time.unscaledDeltaTime });
 			});
 			if (!success) {
 				print(err);
 			}
 		};
 
-		// Switch controls based on preferred user input:
-		preferred.ObserveControlScheme((controlScheme) => {
-			const controlSchemeBin = new Bin();
-
-			if (controlScheme === ControlScheme.MouseKeyboard) {
-				controlSchemeBin.Connect(OnUpdate, updateMouseKeyboardControls);
-			}
-
-			// Clean up current controls when preferred input scheme changes:
-			return () => {
-				controlSchemeBin.Clean();
-			};
-		});
-
 		this.bin.Add(
 			OnUpdate.Connect((dt) => {
 				if (!localCharacterSingleton.IsDefaultMovementEnabled()) return;
 				if (!this.movement) return;
+
+				// Read input for preferred control scheme
+				if (preferred.GetControlScheme() === ControlScheme.MouseKeyboard) {
+					updateMouseKeyboardControls(dt);
+				}
 
 				let sprinting = this.IsSprinting();
 
@@ -184,9 +170,7 @@ export class CharacterInput {
 			this.character.OnAddCustomInputData.Connect(() => {
 				// We clear queued input only when it is consumed by C#. OnAddCustomInputData is the callback
 				// for character movement generating a new move input and consuming the queued input.
-				// We clear next frame since we may run multiple fixed updates per frame, and we don't want to clear
-				// input before we process all pending fixed updates.
-				this.clearQueueNextFrame = true;
+				this.queuedMoveDirections.clear();
 			}),
 		);
 

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Character/LocalCharacter/CharacterInput.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Character/LocalCharacter/CharacterInput.ts
@@ -18,8 +18,9 @@ export class CharacterInput {
 
 	/** If true holding the sprint key will not result in sprinting */
 	private blockSprint = false;
-	
-	private queuedMoveDirections: ({direction: Vector3, dt: number})[] = [];
+
+	private clearQueueNextFrame = false;
+	private queuedMoveDirections: { direction: Vector3; dt: number }[] = [];
 
 	constructor(private readonly character: Character) {
 		this.movement = character.movement;
@@ -39,13 +40,19 @@ export class CharacterInput {
 			if (Game.playerFlags.has("HasTransformMoveDirection")) {
 				this.movement?.SetMoveInput(Vector3.zero, false, false, false);
 			} else {
-				this.movement?.SetMoveInput(Vector3.zero, false, false, false, localCharacterSingleton.GetMoveDirMode());
+				this.movement?.SetMoveInput(
+					Vector3.zero,
+					false,
+					false,
+					false,
+					localCharacterSingleton.GetMoveDirMode(),
+				);
 			}
 		}
 	}
 
 	public SetQueuedMoveDirection(dir: Vector3): void {
-		this.queuedMoveDirections.push({direction: dir, dt: Time.deltaTime});
+		this.queuedMoveDirections.push({ direction: dir, dt: Time.deltaTime });
 	}
 
 	/** Returns `true` if the Humanoid Driver is enabled. */
@@ -97,7 +104,11 @@ export class CharacterInput {
 				const forward = w === s ? 0 : w ? 1 : -1;
 				const sideways = d === a ? 0 : d ? 1 : -1;
 
-				this.queuedMoveDirections.push({direction: new Vector3(sideways, 0, forward), dt});
+				if (this.clearQueueNextFrame) {
+					this.queuedMoveDirections.clear();
+					this.clearQueueNextFrame = false;
+				}
+				this.queuedMoveDirections.push({ direction: new Vector3(sideways, 0, forward), dt });
 			});
 			if (!success) {
 				print(err);
@@ -128,9 +139,14 @@ export class CharacterInput {
 				let moveDir = Vector3.zero;
 				if (this.queuedMoveDirections.size() !== 0) {
 					const totalDt = this.queuedMoveDirections.reduce((acc, input) => (acc += input.dt), 0);
-					moveDir = this.queuedMoveDirections.reduce((acc, input) => {
-						return acc.add(input.direction.mul(dt));
-					}, new Vector3(0, 0, 0)).div(totalDt);
+					moveDir = this.queuedMoveDirections
+						.reduce(
+							(acc, input) => {
+								return acc.add(input.direction.mul(input.dt));
+							},
+							new Vector3(0, 0, 0),
+						)
+						.div(totalDt);
 				}
 
 				if (Game.playerFlags.has("HasTransformMoveDirection")) {
@@ -158,17 +174,21 @@ export class CharacterInput {
 						moveSignal.jump,
 						moveSignal.sprinting,
 						moveSignal.crouch,
-						localCharacterSingleton.GetMoveDirMode()
+						localCharacterSingleton.GetMoveDirMode(),
 					);
 				}
 			}),
 		);
 
-		this.bin.Add(this.character.OnAddCustomInputData.Connect(() => {
-			// We clear queued input only when it is consumed by C#. OnAddCustomInputData is the callback
-			// for character movement generating a new move input and consuming the queued input. 
-			this.queuedMoveDirections.clear();
-		}));
+		this.bin.Add(
+			this.character.OnAddCustomInputData.Connect(() => {
+				// We clear queued input only when it is consumed by C#. OnAddCustomInputData is the callback
+				// for character movement generating a new move input and consuming the queued input.
+				// We clear next frame since we may run multiple fixed updates per frame, and we don't want to clear
+				// input before we process all pending fixed updates.
+				this.clearQueueNextFrame = true;
+			}),
+		);
 
 		this.bin.Add(
 			this.character.onDespawn.Connect(() => {

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Character/LocalCharacter/CharacterInput.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Character/LocalCharacter/CharacterInput.ts
@@ -18,8 +18,8 @@ export class CharacterInput {
 
 	/** If true holding the sprint key will not result in sprinting */
 	private blockSprint = false;
-
-	private queuedMoveDirection = Vector3.zero;
+	
+	private queuedMoveDirections: ({direction: Vector3, dt: number})[] = [];
 
 	constructor(private readonly character: Character) {
 		this.movement = character.movement;
@@ -45,7 +45,7 @@ export class CharacterInput {
 	}
 
 	public SetQueuedMoveDirection(dir: Vector3): void {
-		this.queuedMoveDirection = dir;
+		this.queuedMoveDirections.push({direction: dir, dt: Time.deltaTime});
 	}
 
 	/** Returns `true` if the Humanoid Driver is enabled. */
@@ -97,12 +97,26 @@ export class CharacterInput {
 				const forward = w === s ? 0 : w ? 1 : -1;
 				const sideways = d === a ? 0 : d ? 1 : -1;
 
-				this.queuedMoveDirection = new Vector3(sideways, 0, forward);
+				this.queuedMoveDirections.push({direction: new Vector3(sideways, 0, forward), dt});
 			});
 			if (!success) {
 				print(err);
 			}
 		};
+
+		// Switch controls based on preferred user input:
+		preferred.ObserveControlScheme((controlScheme) => {
+			const controlSchemeBin = new Bin();
+
+			if (controlScheme === ControlScheme.MouseKeyboard) {
+				controlSchemeBin.Connect(OnUpdate, updateMouseKeyboardControls);
+			}
+
+			// Clean up current controls when preferred input scheme changes:
+			return () => {
+				controlSchemeBin.Clean();
+			};
+		});
 
 		this.bin.Add(
 			OnUpdate.Connect((dt) => {
@@ -110,7 +124,15 @@ export class CharacterInput {
 				if (!this.movement) return;
 
 				let sprinting = this.IsSprinting();
-				let moveDir = this.queuedMoveDirection;
+
+				let moveDir = Vector3.zero;
+				if (this.queuedMoveDirections.size() !== 0) {
+					const totalDt = this.queuedMoveDirections.reduce((acc, input) => (acc += input.dt), 0);
+					moveDir = this.queuedMoveDirections.reduce((acc, input) => {
+						return acc.add(input.direction.mul(dt));
+					}, new Vector3(0, 0, 0)).div(totalDt);
+				}
+
 				if (Game.playerFlags.has("HasTransformMoveDirection")) {
 					moveDir = this.movement.TransformMoveDirection(moveDir, localCharacterSingleton.GetMoveDirMode());
 				}
@@ -141,25 +163,18 @@ export class CharacterInput {
 				}
 			}),
 		);
+
+		this.bin.Add(this.character.OnAddCustomInputData.Connect(() => {
+			// We clear queued input only when it is consumed by C#. OnAddCustomInputData is the callback
+			// for character movement generating a new move input and consuming the queued input. 
+			this.queuedMoveDirections.clear();
+		}));
+
 		this.bin.Add(
 			this.character.onDespawn.Connect(() => {
 				this.Destroy();
 			}),
 		);
-
-		// Switch controls based on preferred user input:
-		preferred.ObserveControlScheme((controlScheme) => {
-			const controlSchemeBin = new Bin();
-
-			if (controlScheme === ControlScheme.MouseKeyboard) {
-				controlSchemeBin.Connect(OnUpdate, updateMouseKeyboardControls);
-			}
-
-			// Clean up current controls when preferred input scheme changes:
-			return () => {
-				controlSchemeBin.Clean();
-			};
-		});
 	}
 
 	public Destroy() {


### PR DESCRIPTION
This PR queues input per frame and calculates a fractional move direction when FPS is higher than tick rate. This allows players with higher FPS to have more precise control over their character.

For example, if a player has 80 fps, they will have 2 frames before 1 fixed update. If the player presses "forward" during either frame, the character will behave as if both frames had the forward control pressed.

Now, if the player presses forward for only 1 of those frames, the input vector will be half of the length compared the input vector if both frames are pressed. Half length will result in a smaller forward movement, which matches better with the players short press of the "forward" key.

The intention is to give players with higher FPS more precise control over their movement instead of giving them the precision of 40 tick movement.

Additionally, the reordered "ObserveControlScheme" connection removes a 1 frame delay on input. Because the OnUpdate signal does not have a priority, we were reading the input for the frame _after_ sending the input to C#, meaning we were always sending the previous frame's input instead of the current frame.