### PR TITLE
Add a parent gameobject for the mobile buttons

### DIFF
--- a/Assets/AirshipPackages/@Easy/Core/Prefabs/UI/MobileControls/MobileControlsCanvas.prefab
+++ b/Assets/AirshipPackages/@Easy/Core/Prefabs/UI/MobileControls/MobileControlsCanvas.prefab
@@ -37,6 +37,41 @@ RectTransform:
   m_AnchoredPosition: {x: 231, y: 191}
   m_SizeDelta: {x: 179.9729, y: 179.9729}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &6837006853897410262
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5799329173041500672}
+  m_Layer: 8
+  m_Name: MobileButtonContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5799329173041500672
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6837006853897410262}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 279624506939109690}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -45}
+  m_SizeDelta: {x: 0, y: -90}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &7090916502956745191
 GameObject:
   m_ObjectHideFlags: 0
@@ -69,6 +104,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 5799329173041500672}
   - {fileID: 9038067902904019132}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -197,6 +233,24 @@ MonoBehaviour:
       nullable: 0
       serializedValue: 
       serializedObject: {fileID: 281396559919837435}
+      modified: 1
+    - name: buttonContainer
+      type: object
+      objectType: Transform
+      items:
+        type: 
+        objectType: 
+        serializedItems: []
+        objectRefs: []
+      refPath: 
+      fileRef: 
+      jsDocs:
+        text: []
+        tags: []
+      decorators: []
+      nullable: 0
+      serializedValue: 
+      serializedObject: {fileID: 5799329173041500672}
       modified: 1
     displayIcon: {fileID: 0}
     displayName: 

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Input/AirshipInputSingleton.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Input/AirshipInputSingleton.ts
@@ -116,7 +116,7 @@ export class AirshipInputSingleton {
 	/*
 	 * Core mobile inputs
 	 */
-	private mobileControlCanvas: MobileControlsCanvas;
+	public mobileControlCanvas: MobileControlsCanvas;
 
 	public preferredControls = new PreferredControls();
 
@@ -549,9 +549,9 @@ export class AirshipInputSingleton {
 	 * @param config A `MobileButtonConfig` that describes the look and feel of this button.
 	 */
 	public CreateMobileButton(actionName: string, anchoredPosition: Vector2, config?: MobileButtonConfig): GameObject {
-		const mobileButton = Object.Instantiate(config?.prefab ?? this.mobileButtonPrefab);
+		const buttonParent = this.mobileControlCanvas.buttonContainer;
+		const mobileButton = Object.Instantiate(config?.prefab ?? this.mobileButtonPrefab, buttonParent);
 		mobileButton.name = "Mobile Button (" + actionName + ")";
-		mobileButton.transform.SetParent(this.mobileControlsContainer.transform);
 
 		const airshipButton = mobileButton.GetAirshipComponent<AirshipMobileButton>();
 		airshipButton?.SetStartingScale(config?.scale ? new Vector3(config.scale.x, config.scale.y, 1) : Vector3.one);

--- a/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/MobileControlsCanvas.ts
+++ b/Assets/AirshipPackages/@Easy/Core/Shared/Input/Mobile/MobileControlsCanvas.ts
@@ -12,6 +12,8 @@ import TouchJoystick from "./TouchJoystick";
 export default class MobileControlsCanvas extends AirshipBehaviour {
 	public staticJoystick: TouchJoystick;
 	public dynamicJoystick: DynamicJoystick;
+	
+	public buttonContainer: Transform;
 	private isJoystickDynamic = true;
 
 	private crouchToggleBtn: GameObject;


### PR DESCRIPTION
* Added an empty container that contains the mobile buttons when they spawn in.

Wanted this so I could reference the area that the buttons are in to adjust the safe area to match in bedwars.